### PR TITLE
docs. Model "original_url" attribute semantics

### DIFF
--- a/docs/modelsNameGet.md
+++ b/docs/modelsNameGet.md
@@ -16,6 +16,7 @@ Success response:
 {
     "name": "acme19.2",
     "display_name": "Acme IP phone v19 rev. 2",
+    "original_url": "/tancredi/api/v1/models/acme19.2?original=1",
     "variables": {
         "var1": "value1",
         "var2": "value2"
@@ -36,9 +37,44 @@ Failed response:
 }
 ```
 
+## Get a model original state
+
+The **optional** `original_url` attribute is a reference to another resource or
+the resource itself, representing a phone model in its initial state, where all
+variables are at their factory default values.
+
+The purpose of this reference is helping the restore of the initial values of
+the model variables, to clear any user customization.
+
+See also the [model "original" attribute description](modelsPost#attributes).
+
+Get the variables factory default value for a model, by adding the `original=1`
+parameter to the query string:
+
+    GET /tancredi/api/v1/models/acme19.2?original=1
+
+(empty request body)
+
+Success response:
+
+    Status: 200 OK
+
+```json
+{
+    "name": "acme19.2",
+    "display_name": "Acme IP phone v19 rev. 2",
+    "variables": {
+        "var1": "orig-value1"
+    }
+}
+```
+
+Note that the `original_url` attribute is not set, because the returned model is
+at its factory-default state.
+
 ## Get inherited variables
 
-Get the model `name` with inherited variables values, by adding `inherit=1`
+Get the model `name` with inherited variables values, by adding the `inherit=1`
 parameter to the query string:
 
     GET /tancredi/api/v1/models/acme19.2?inherit=1
@@ -53,6 +89,7 @@ Success response:
 {
     "name": "acme19.2",
     "display_name": "Acme IP phone v19 rev. 2",
+    "original_url": "/tancredi/api/v1/models/acme19.2?original=1",
     "variables": {
         "var1": "value1",
         "var2": "value2",

--- a/docs/modelsPost.md
+++ b/docs/modelsPost.md
@@ -1,5 +1,12 @@
 # POST /models
 
+## Attributes
+
+* `name` is the unique identifier of a model resource
+* `original` is the name of an already existing model
+* `display_name` is a human readable string for the model itself
+* `variables` is an object where each key-value represents a variable with its corresponding value
+
 ## Create a new model
 
 Create a new phone model instance and add it to the models collection.
@@ -11,6 +18,7 @@ POST /tancredi/api/v1/models
 ```json
 {
     "name": "acme19.2",
+    "original": "acme19.2",
     "display_name": "Acme IP phone v19 rev. 2",
     "variables": {
         "var1": "value1",
@@ -28,6 +36,7 @@ Success response:
 {
     "name": "acme19.2",
     "display_name": "Acme IP phone v19 rev. 2",
+    "original_url": "/tancredi/api/v1/models/acme19.2?original=1",
     "variables": {
         "var1": "value1",
         "var2": "value2"


### PR DESCRIPTION
The `original_url` attribute purpose...

> is helping the restore of the initial values of
> the model variables, to clear any user customization.