### PR TITLE
Delete shortlabel linekey parameter

### DIFF
--- a/data/templates/yealink-MAC_ADDRESS.tmpl
+++ b/data/templates/yealink-MAC_ADDRESS.tmpl
@@ -585,7 +585,6 @@ linekey.{{ number }}.value = {{ _context['linekey_value_' ~ number]|default }}
 linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number]|default }}
 linekey.{{ number }}.extension = {{ _context['linekey_extension_' ~ number]|default }}
 linekey.{{ number }}.xml_phonebook = {{ _context['linekey_xml_phonebook_' ~ number]|default }}
-linekey.{{ number }}.shortlabel = {{ _context['linekey_shortlabel_' ~ number]|default }}
 
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
The linekey.shortlabel parameter is in Yealink example file but isn't in Yealink description of configuration parameters in  Common.cfg File