### PR TITLE
Initial cap_ variables setup

### DIFF
--- a/data/scopes/fanvil-x3.ini
+++ b/data/scopes/fanvil-x3.ini
@@ -12,3 +12,5 @@ cap_softkey_count = 4
 cap_softkey_type_blacklist =
 cap_expkey_count =
 cap_expkey_type_blacklist =
+cap_ringtone_count = 9
+cap_ringtone_blacklist = custom_url

--- a/data/scopes/fanvil-x4.ini
+++ b/data/scopes/fanvil-x4.ini
@@ -1,12 +1,12 @@
 [metadata]
 inheritFrom = "defaults"
 scopeType = "model"
-displayName = "Fanvil X3"
+displayName = "Fanvil X4"
 
 [data]
 model="fanvil-x3"
 tmpl_phone = "fanvil-x3.tmpl"
-cap_linekey_count = 2
+cap_linekey_count = 6
 cap_linekey_type_blacklist =
 cap_softkey_count = 4
 cap_softkey_type_blacklist =

--- a/data/scopes/fanvil-x4.ini
+++ b/data/scopes/fanvil-x4.ini
@@ -12,3 +12,5 @@ cap_softkey_count = 4
 cap_softkey_type_blacklist =
 cap_expkey_count =
 cap_expkey_type_blacklist =
+cap_ringtone_count = 9
+cap_ringtone_blacklist = custom_url

--- a/data/scopes/fanvil-x5.ini
+++ b/data/scopes/fanvil-x5.ini
@@ -1,8 +1,14 @@
 [metadata]
 inheritFrom = "defaults"
 scopeType = "model"
-displayName = "Fanvil X5/X6"
+displayName = "Fanvil X5"
 
 [data]
 model="fanvil-x5"
 tmpl_phone = "fanvil-x5.tmpl"
+cap_linekey_count = 8
+cap_linekey_type_blacklist =
+cap_softkey_count = 4
+cap_softkey_type_blacklist =
+cap_expkey_count =
+cap_expkey_type_blacklist =

--- a/data/scopes/fanvil-x5.ini
+++ b/data/scopes/fanvil-x5.ini
@@ -12,3 +12,5 @@ cap_softkey_count = 4
 cap_softkey_type_blacklist =
 cap_expkey_count =
 cap_expkey_type_blacklist =
+cap_ringtone_count = 9
+cap_ringtone_blacklist = custom_url

--- a/data/scopes/fanvil-x6.ini
+++ b/data/scopes/fanvil-x6.ini
@@ -1,12 +1,12 @@
 [metadata]
 inheritFrom = "defaults"
 scopeType = "model"
-displayName = "Fanvil X3"
+displayName = "Fanvil X6"
 
 [data]
-model="fanvil-x3"
-tmpl_phone = "fanvil-x3.tmpl"
-cap_linekey_count = 2
+model="fanvil-x5"
+tmpl_phone = "fanvil-x5.tmpl"
+cap_linekey_count = 12
 cap_linekey_type_blacklist =
 cap_softkey_count = 4
 cap_softkey_type_blacklist =

--- a/data/scopes/fanvil-x6.ini
+++ b/data/scopes/fanvil-x6.ini
@@ -12,3 +12,5 @@ cap_softkey_count = 4
 cap_softkey_type_blacklist =
 cap_expkey_count =
 cap_expkey_type_blacklist =
+cap_ringtone_count = 9
+cap_ringtone_blacklist = custom_url


### PR DESCRIPTION
Initial values of `caps_` model variables for Fanvil phones X3, X4, X5, X6

Set the number of available keys

- `cap_linekey_count` number of DSS/Line keys 
- `cap_expkey_count` number of DSS/Line keys installed by expansion modules - can be empty, if no module is installed at all
- `cap_softkey_count` number of soft keys

Please check the meaning of variables is valid for other vendors!