### PR TITLE
Revert "Refresh token 1 instead of remove it"

### DIFF
--- a/src/Entity/TokenManager.php
+++ b/src/Entity/TokenManager.php
@@ -10,7 +10,6 @@ class TokenManager {
         } elseif (file_exists($config['rw_dir'] . 'tokens/'.$token)) {
             $id = trim(file_get_contents($config['rw_dir'] . 'tokens/'.$token));
             TokenManager::deleteTokenForId($id,$config['rw_dir'] . 'first_access_tokens/');
-            TokenManager::createToken(uniqid($prefix = rand(), $more_entropy = TRUE),$id,TRUE);
             return $id;
         } else {
             // Token not found


### PR DESCRIPTION
Avoid side effects (config backup?): tok1 rotates on every tok2 request, actually changing the filesystem state of `/var/lib/tancredi/data/first_access_tokens`.


Reverts nethesis/tancredi#37