### PR TITLE
add provisioning_url_host even in /provisioning/{filename} api

### DIFF
--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -149,8 +149,11 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
     // Add provisioning_complete variable
     $scope_data['provisioning_complete'] = '';
 
-    // Add provisioning_url_path variable
+    // Add provisioning_url_path and provisioning_url_host variables
     $scope_data['provisioning_url_path'] = $config['provisioning_url_path'];
+    if(empty($scope_data['provisioning_url_host'])) {
+        $scope_data['provisioning_url_host'] = gethostname();
+    }
 
     // Add user agent
     $scope_data['provisioning_user_agent'] = $_SERVER['HTTP_USER_AGENT'];


### PR DESCRIPTION
I've added `provisioning_url_host` into `/provisioning/{filename} api` only because it's present into `/provisioning/{token}/{filename}` api and I think these two apis have the same behavior.
It's reasonable ?