### PR TITLE
Provisioning url rework

### DIFF
--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,8 +4,6 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
-provisioning_url_path = "provisioning"
-provisioning_url_scheme = "http"
 hostname =
 timezone = "UTC"
 tonezone = "us"

--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,6 +4,8 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
+hostname =
+provisioning_url_scheme = "http"
 sip_tls_port = 5061
 sip_udp_port = 5060
 timezone = "UTC"

--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,7 +4,6 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
-hostname =
 timezone = "UTC"
 tonezone = "us"
 language = "en"

--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,6 +4,8 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
+sip_tls_port = 5061
+sip_udp_port = 5060
 timezone = "UTC"
 tonezone = "us"
 language = "en"

--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,6 +4,9 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
+provisioning_url_path = "provisioning"
+provisioning_url_scheme = "http"
+hostname =
 timezone = "UTC"
 tonezone = "us"
 language = "en"

--- a/data/scopes/fanvil-X3.ini
+++ b/data/scopes/fanvil-X3.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Fanvil X3"
 
 [data]
+provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X3.tmpl"
 cap_linekey_count = 2
 cap_linekey_type_blacklist =

--- a/data/scopes/fanvil-X4.ini
+++ b/data/scopes/fanvil-X4.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Fanvil X4"
 
 [data]
+provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X3.tmpl"
 cap_linekey_count = 6
 cap_linekey_type_blacklist =

--- a/data/scopes/fanvil-X5.ini
+++ b/data/scopes/fanvil-X5.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Fanvil X5"
 
 [data]
+provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 cap_linekey_count = 8
 cap_linekey_type_blacklist =

--- a/data/scopes/fanvil-X6.ini
+++ b/data/scopes/fanvil-X6.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Fanvil X6"
 
 [data]
+provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 cap_linekey_count = 12
 cap_linekey_type_blacklist =

--- a/data/scopes/gigaset-Maxwell-2.ini
+++ b/data/scopes/gigaset-Maxwell-2.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Maxwell 2"
 
 [data]
+provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count = 8
 cap_linekey_type_blacklist =

--- a/data/scopes/gigaset-Maxwell-3.ini
+++ b/data/scopes/gigaset-Maxwell-3.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Maxwell 3"
 
 [data]
+provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count = 8
 cap_linekey_type_blacklist =

--- a/data/scopes/gigaset-Maxwell-Basic.ini
+++ b/data/scopes/gigaset-Maxwell-Basic.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Maxwell Basic"
 
 [data]
+provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count =
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D120.ini
+++ b/data/scopes/snom-D120.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D120"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 0
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D305.ini
+++ b/data/scopes/snom-D305.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D305"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D315.ini
+++ b/data/scopes/snom-D315.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D315"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D345.ini
+++ b/data/scopes/snom-D345.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D345"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 48
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D375.ini
+++ b/data/scopes/snom-D375.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D375"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 12
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D385.ini
+++ b/data/scopes/snom-D385.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D385"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 48
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D710.ini
+++ b/data/scopes/snom-D710.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D710"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D712.ini
+++ b/data/scopes/snom-D712.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D712"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D715.ini
+++ b/data/scopes/snom-D715.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D715"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D717.ini
+++ b/data/scopes/snom-D717.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D717"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 3
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D725.ini
+++ b/data/scopes/snom-D725.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D725"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 18
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D735.ini
+++ b/data/scopes/snom-D735.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D735"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 32
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D745.ini
+++ b/data/scopes/snom-D745.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D745"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 32
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D765.ini
+++ b/data/scopes/snom-D765.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D765"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 16
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D785.ini
+++ b/data/scopes/snom-D785.ini
@@ -4,6 +4,7 @@ scopeType = "model"
 displayName = "Snom D785"
 
 [data]
+provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 24
 cap_linekey_type_blacklist =

--- a/data/scopes/yealink-T19P_E2.ini
+++ b/data/scopes/yealink-T19P_E2.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T19P E2"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T21P_E2.ini
+++ b/data/scopes/yealink-T21P_E2.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T21P E2"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T23G.ini
+++ b/data/scopes/yealink-T23G.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T23G"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T27G.ini
+++ b/data/scopes/yealink-T27G.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T27G"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T29G.ini
+++ b/data/scopes/yealink-T29G.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T29G"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T40PG.ini
+++ b/data/scopes/yealink-T40PG.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T40P/G"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T41PS.ini
+++ b/data/scopes/yealink-T41PS.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T41P/S"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T42GS.ini
+++ b/data/scopes/yealink-T42GS.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T42G/S"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T46GS.ini
+++ b/data/scopes/yealink-T46GS.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T46G/S"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T48GS.ini
+++ b/data/scopes/yealink-T48GS.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T48G/S"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T49G.ini
+++ b/data/scopes/yealink-T49G.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T49G"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T53.ini
+++ b/data/scopes/yealink-T53.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T53"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T54.ini
+++ b/data/scopes/yealink-T54.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T54"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T56.ini
+++ b/data/scopes/yealink-T56.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T56"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T57.ini
+++ b/data/scopes/yealink-T57.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T57"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/scopes/yealink-T58.ini
+++ b/data/scopes/yealink-T58.ini
@@ -4,4 +4,5 @@ scopeType = "model"
 displayName = "Yealink T58"
 
 [data]
+provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'

--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -648,7 +648,7 @@ AP Pswd Encryption :0
 Config File Name   :{{ 'http' in provisioning_url_scheme ? (provisioning_url_path | trim('/', 'left') ~ tok2 ~ '/$mac.cfg') : '$mac.cfg' }}
 Config File Key    :
 Common Cfg File Key:
-Download Server IP :{{ provisioning_url_host }}
+Download Server IP :{{ hostname }}
 Download Protocol  :{{ fanvil.scheme_map(provisioning_url_scheme) }}
 Download Mode      :1
 Download Interval  :1

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -850,7 +850,7 @@ Common Cfg File Key:
 Download CommonConf:0
 Save Provision Info:0
 Check FailTimes    :5
-Flash Server IP    :{{ provisioning_url_host }}
+Flash Server IP    :{{ hostname }}
 Flash File Name    :{{ 'http' in provisioning_url_scheme ? (provisioning_url_path | trim('/', 'left') ~ tok2 ~ '/$mac.cfg') : '$mac.cfg' }}
 Flash Protocol     :{{ fanvil.scheme_map(provisioning_url_scheme) }}
 Flash Mode         :1

--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -19,7 +19,7 @@
     
     <param name="FirmwareManagment.AutomaticCheckForUpdates" value="0" />
     <param name="System.Provision.Period" value="{{ provisioning_complete ? '0' : '600' }}" />
-    <param name="System.Provision.ProvisioningServer" value="{{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/%MACD.xml" }}" />
+    <param name="System.Provision.ProvisioningServer" value="{{ provisioning_url2 }}" />
 
     {% if provisioning_complete -%}
     <param name="SIP.Port" value="{{ account_server_port_1 ?: account_srtp_encryption_1 == 'compulsory' ? '5061' : '5060' }}" />

--- a/data/templates/sangoma.tmpl
+++ b/data/templates/sangoma.tmpl
@@ -180,8 +180,8 @@
         <P196 para="UserPassword" >{{ userpw ?: '1234' }}</P196>
         <!--Management/AutoProvision-->
         <P212 para="FirmwareUpGrade.UrgrateMode">{{ provisioning_url_scheme == 'https' ? '3' : '1' }}</P212>
-        <P192 para="FirmwareUpGrade.FirmwareServerPath">{{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}" }}</P192>
-        <P237 para="FirmwareUpGrade.ConfigServerPath">{{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}" }}</P237>
+        <P192 para="FirmwareUpGrade.FirmwareServerPath">{{ provisioning_url2 }}</P192>
+        <P237 para="FirmwareUpGrade.ConfigServerPath">{{ provisioning_url2 }}</P237>
         <P1145 para="FirmwareUpGrade.AllowDHCPOption">66</P1145>
         <P145 para="FirmwareUpGrade.ToOverrideServer">0</P145>
         <P194 para="FirmwareUpGrade.AutoUpgrade">{{ provisioning_complete ? '0' : '1' }}</P194>

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -63,7 +63,7 @@
         <http_user perm="">admin</http_user>
         <http_password perm="">{{ adminpw }}</http_password>
 
-        <setting_server perm="RW">{{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/{mac}.xml" }}</setting_server>
+        <setting_server perm="RW">{{ provisioning_url2 }}</setting_server>
         {# snom allowed values: 3..15. active_backlight_level values: 1..10 #}
         <backlight perm="">{{ active_backlight_level + 5 }}</backlight>
         {# snom allowed values: 0..15. inactive_backlight_level values: 0 (off), 1 (low) #}

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -166,7 +166,7 @@ static.zero_touch.network_fail_wait_times = 8
 #######################################################################################
 ##                                   Autop URL                                       ##
 #######################################################################################
-static.auto_provision.server.url = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
+static.auto_provision.server.url = {{ provisioning_url2 }}
 static.auto_provision.server.username =
 static.auto_provision.server.password =
 
@@ -279,7 +279,7 @@ static.managementserver.connection_request_username =
 #######################################################################################
 ##                            Firmware Update                                        ##
 #######################################################################################
-static.firmware.url = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
+static.firmware.url = {{ provisioning_url2 }}
 
 #######################################################################################
 ##                            Confguration                                           ##
@@ -1651,10 +1651,10 @@ handset.{{ handset }}.name = {{ _context['handset_name_' ~ line]|default }}
 over_the_air.base_trigger = 1
 over_the_air.handset_tip = 1
 over_the_air.handset_trigger = 1
-over_the_air.url = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
-over_the_air.url.w52h = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
-over_the_air.url.w53h = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
-over_the_air.url.w56h = {{ "#{provisioning_url_scheme}://#{provisioning_url_host}#{provisioning_url_path}#{tok2}/" }}
+over_the_air.url = {{ provisioning_url2 }}
+over_the_air.url.w52h = {{ provisioning_url2 }}
+over_the_air.url.w53h = {{ provisioning_url2 }}
+over_the_air.url.w56h = {{ provisioning_url2 }}
 
 auto_provision.custom.handset.protect = 1
 auto_provision.handset_configured.enable = 1

--- a/docs/phonesMacGet.md
+++ b/docs/phonesMacGet.md
@@ -20,6 +20,8 @@ Success response:
     "tok1": "3cb63010-6e80-41ff-9437-c4b1413975db",
     "tok2": "88eebf1d-b860-498f-8bfa-4947e170873b",
     "model_url": "/tancredi/api/v1/models/acme19.2",
+    "provisioning_url1": "https://myexample.com/provisioning/3cb63010-6e80-41ff-9437-c4b1413975db/%MACD.xml",
+    "provisioning_url2": "https://myexample.com/provisioning/88eebf1d-b860-498f-8bfa-4947e170873b/%MACD.xml",
     "variables": {
         "var1": "value1",
         "var2": "value2"

--- a/docs/phonesMacPatch.md
+++ b/docs/phonesMacPatch.md
@@ -45,6 +45,8 @@ Success response:
     "display_name": "Acme",
     "tok1": "3cb63010-6e80-41ff-9437-c4b1413975db",
     "tok2": "88eebf1d-b860-498f-8bfa-4947e170873b",
+    "provisioning_url1": "https://myexample.com/provisioning/3cb63010-6e80-41ff-9437-c4b1413975db/%MACD.xml",
+    "provisioning_url2": "https://myexample.com/provisioning/88eebf1d-b860-498f-8bfa-4947e170873b/%MACD.xml",
     "model_url": "/tancredi/api/v1/models/acme19.2-custom",
     "variables": {
         "var1": "value1",
@@ -53,13 +55,14 @@ Success response:
 }
 ```
 
-The `model_uriref` changes with `model` automatically, so the new resource state
-is returned in the response.
+The `model_url` changes with `model` automatically, so the new resource state
+is returned in the response. Also `provisioning_url1` and `provisioning_url2` 
+can be changed accordingly.
 
 ## Read only attributes
 
-Attributes `mac`, `tok1`, `tok3` are read-only. Attempt to change their values
-causes the whole request to fail.
+Attributes `mac`, `tok1`, `tok2`, `provisioning_url1`, `provisioning_url2` are
+read-only. Attempt to change their values causes the whole request to fail.
 
     PATCH /tancredi/api/v1/phones/01-23-45-67-89-AB
 
@@ -68,7 +71,9 @@ causes the whole request to fail.
     "mac": "doesn't work",
     "model_url": "doesn't work",
     "tok1": "doesn't work",
-    "tok2": "doesn't work"
+    "tok2": "doesn't work",
+    "provisioning_url1": "doesn't work",
+    "provisioning_url2": "doesn't work",
 }
 ```
 

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -478,9 +478,18 @@ function getPhoneScope($mac,$storage,$logger,$inherit = false) {
         'variables' => $scope_data,
         'model_url' => $config['api_url_path'] . "models/" . $scope->metadata['inheritFrom']
     );
-    $provisioning_url_path = trim($vars['provisioning_url_path'], '/');
-    $results['provisioning_url1'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}/{$tok1}/{$vars['provisioning_url_filename']}";
-    $results['provisioning_url2'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}/{$tok2}/{$vars['provisioning_url_filename']}";
+    $provisioning_url_path = trim($vars['provisioning_url_path'], '/') . '/';
+    if($tok1 && $vars['provisioning_url_scheme'] && $vars['server_name']) {
+        $results['provisioning_url1'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}{$tok1}/{$vars['provisioning_url_filename']}";
+    } else {
+        $results['provisioning_url1'] = NULL;
+    }
+    if($tok2 && $vars['provisioning_url_scheme'] && $vars['server_name']) {
+        $results['provisioning_url2'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}";
+    } else {
+        // Never return back an invalid provisioning URL!
+        throw new \LogicException(sprintf("%s - malformed provisioning_url2", 1582905675));
+    }
     return $results;
 }
 

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -479,13 +479,13 @@ function getPhoneScope($mac,$storage,$logger,$inherit = false) {
         'model_url' => $config['api_url_path'] . "models/" . $scope->metadata['inheritFrom']
     );
     $provisioning_url_path = trim($vars['provisioning_url_path'], '/') . '/';
-    if($tok1 && $vars['provisioning_url_scheme'] && $vars['server_name']) {
-        $results['provisioning_url1'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}{$tok1}/{$vars['provisioning_url_filename']}";
+    if($tok1 && $vars['provisioning_url_scheme'] && $vars['hostname']) {
+        $results['provisioning_url1'] = "{$vars['provisioning_url_scheme']}://{$vars['hostname']}/{$provisioning_url_path}{$tok1}/{$vars['provisioning_url_filename']}";
     } else {
         $results['provisioning_url1'] = NULL;
     }
-    if($tok2 && $vars['provisioning_url_scheme'] && $vars['server_name']) {
-        $results['provisioning_url2'] = "{$vars['provisioning_url_scheme']}://{$vars['server_name']}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}";
+    if($tok2 && $vars['provisioning_url_scheme'] && $vars['hostname']) {
+        $results['provisioning_url2'] = "{$vars['provisioning_url_scheme']}://{$vars['hostname']}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}";
     } else {
         // Never return back an invalid provisioning URL!
         throw new \LogicException(sprintf("%s - malformed provisioning_url2", 1582905675));

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -66,11 +66,9 @@ $app->get('/{token}/{filename}', function(Request $request, Response $response, 
         $scope_data['provisioning_complete'] = '';
     }
 
-    // Add provisioning_url_path and hostname variables
-    $scope_data['provisioning_url_path'] = $config['provisioning_url_path'];
-    if(empty($scope_data['hostname'])) {
-        $scope_data['hostname'] = gethostname();
-    }
+    // Ensure default values for provisioning_url_path and hostname variables
+    $scope_data['provisioning_url_path'] = $scope_data['provisioning_url_path'] ?: $config['provisioning_url_path'];
+    $scope_data['hostname'] = $scope_data['hostname'] ?: gethostname();
 
     // Add user agent
     $scope_data['provisioning_user_agent'] = $_SERVER['HTTP_USER_AGENT'];
@@ -149,11 +147,9 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
     // Add provisioning_complete variable
     $scope_data['provisioning_complete'] = '';
 
-    // Add provisioning_url_path and hostname variables
-    $scope_data['provisioning_url_path'] = $config['provisioning_url_path'];
-    if(empty($scope_data['hostname'])) {
-        $scope_data['hostname'] = gethostname();
-    }
+    // Ensure default values for provisioning_url_path and hostname variables
+    $scope_data['provisioning_url_path'] = $scope_data['provisioning_url_path'] ?: $config['provisioning_url_path'];
+    $scope_data['hostname'] = $scope_data['hostname'] ?: gethostname();
 
     // Add user agent
     $scope_data['provisioning_user_agent'] = $_SERVER['HTTP_USER_AGENT'];

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -66,10 +66,10 @@ $app->get('/{token}/{filename}', function(Request $request, Response $response, 
         $scope_data['provisioning_complete'] = '';
     }
 
-    // Add provisioning_url_path and provisioning_url_host variables
+    // Add provisioning_url_path and hostname variables
     $scope_data['provisioning_url_path'] = $config['provisioning_url_path'];
-    if(empty($scope_data['provisioning_url_host'])) {
-        $scope_data['provisioning_url_host'] = gethostname();
+    if(empty($scope_data['hostname'])) {
+        $scope_data['hostname'] = gethostname();
     }
 
     // Add user agent
@@ -149,8 +149,11 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
     // Add provisioning_complete variable
     $scope_data['provisioning_complete'] = '';
 
-    // Add provisioning_url_path variable
+    // Add provisioning_url_path and hostname variables
     $scope_data['provisioning_url_path'] = $config['provisioning_url_path'];
+    if(empty($scope_data['hostname'])) {
+        $scope_data['hostname'] = gethostname();
+    }
 
     // Add user agent
     $scope_data['provisioning_user_agent'] = $_SERVER['HTTP_USER_AGENT'];

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -120,5 +120,48 @@ class Scope {
         }
         return null;
     }
+
+    public static function getPhoneScope($mac, $storage, $logger, $inherit = false) {
+        global $config;
+        $scope = new \Tancredi\Entity\Scope($mac, $storage, $logger, null);
+        $vars = $scope->getVariables();
+
+        $hostname = empty($vars['hostname']) ? $config['hostname'] : $vars['hostname'];
+        $provisioning_url_path = trim(empty($vars['provisioning_url_path']) ? $config['provisioning_url_path'] : $vars['provisioning_url_path'], '/') . '/';
+        $provisioning_url_scheme = empty($vars['provisioning_url_scheme']) ? $config['provisioning_url_scheme'] : $vars['provisioning_url_scheme'];
+
+        if ($inherit) {
+            $scope_data = $vars;
+            $scope_data['hostname'] = $hostname;
+            $scope_data['provisioning_url_path'] = $provisioning_url_path;
+            $scope_data['provisioning_url_scheme'] = $provisioning_url_scheme;
+        } else {
+            $scope_data = $scope->data;
+        }
+        $tok1 = \Tancredi\Entity\TokenManager::getToken1($mac);
+        $tok2 = \Tancredi\Entity\TokenManager::getToken2($mac);
+        $results = array(
+            'mac' => $mac,
+            'model' => $scope->metadata['inheritFrom'],
+            'display_name' => $scope->metadata['displayName'],
+            'tok1' => $tok1,
+            'tok2' => $tok2,
+            'variables' => empty($scope_data) ? new \stdClass() : $scope_data,
+            'model_url' => $config['api_url_path'] . "models/" . $scope->metadata['inheritFrom']
+        );
+
+        if($tok1 && $provisioning_url_scheme && $hostname) {
+            $results['provisioning_url1'] = "{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok1}/{$vars['provisioning_url_filename']}";
+        } else {
+            $results['provisioning_url1'] = NULL;
+        }
+        if($tok2 && $provisioning_url_scheme && $hostname) {
+            $results['provisioning_url2'] = "{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}";
+        } else {
+            // Never return back an invalid provisioning URL!
+            throw new \LogicException(sprintf("%s - malformed provisioning_url2: %s", 1582905675));
+        }
+        return $results;
+    }
 }
 

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -126,9 +126,9 @@ class Scope {
         $scope = new \Tancredi\Entity\Scope($mac, $storage, $logger, null);
         $vars = $scope->getVariables();
 
-        $hostname = empty($vars['hostname']) ? $config['hostname'] : $vars['hostname'];
-        $provisioning_url_path = trim(empty($vars['provisioning_url_path']) ? $config['provisioning_url_path'] : $vars['provisioning_url_path'], '/') . '/';
-        $provisioning_url_scheme = empty($vars['provisioning_url_scheme']) ? $config['provisioning_url_scheme'] : $vars['provisioning_url_scheme'];
+        $hostname = empty($vars['hostname']) ? gethostname() : $vars['hostname'];
+        $provisioning_url_path = trim($config['provisioning_url_path'], '/') . '/';
+        $provisioning_url_scheme = empty($vars['provisioning_url_scheme']) ? 'http' : $vars['provisioning_url_scheme'];
 
         if ($inherit) {
             $scope_data = $vars;
@@ -159,7 +159,7 @@ class Scope {
             $results['provisioning_url2'] = "{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}";
         } else {
             // Never return back an invalid provisioning URL!
-            throw new \LogicException(sprintf("%s - malformed provisioning_url2: %s", 1582905675));
+            throw new \LogicException(sprintf("%s - malformed provisioning_url2", 1582905675));
         }
         return $results;
     }


### PR DESCRIPTION
Return from `phonesMacGet` two new read-only attributes:
- provisioning_url1 (tok1)
- provisioning_url2 (tok2)

Use the same function `getPhoneScope()` for both endpoints: provisioning and api.