### PR TITLE
Serve Content-Type headers

### DIFF
--- a/data/patterns.d/fanvil.ini
+++ b/data/patterns.d/fanvil.ini
@@ -2,4 +2,4 @@
 pattern = "0c383e([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.cfg"
 scopeid = "0c-38-3e-$1-$2-$3"
 template = "tmpl_phone"
-
+content_type = "text/plain; charset=utf-8"

--- a/data/patterns.d/gigaset.ini
+++ b/data/patterns.d/gigaset.ini
@@ -2,4 +2,4 @@
 pattern = "7c2f80([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.xml"
 scopeid = "7c-2f-80-$1-$2-$3"
 template = "tmpl_phone"
-
+content_type = "text/xml; charset=utf-8"

--- a/data/patterns.d/sangoma.ini
+++ b/data/patterns.d/sangoma.ini
@@ -2,3 +2,4 @@
 pattern = "cfg005058([A-F0-9]{2})([A-F0-9]{2})([A-F0-9]{2})\.xml"
 scopeid = "00-50-58-$1-$2-$3"
 template = "tmpl_phone"
+content_type = "text/xml; charset=utf-8"

--- a/data/patterns.d/snom.ini
+++ b/data/patterns.d/snom.ini
@@ -2,3 +2,4 @@
 pattern = "000413([A-Fa-f0-9]{2})([A-Fa-f0-9]{2})([A-Fa-f0-9]{2})\.xml"
 scopeid = "00-04-13-$1-$2-$3"
 template = "tmpl_phone"
+content_type = "text/xml; charset=utf-8"

--- a/data/patterns.d/yealink.ini
+++ b/data/patterns.d/yealink.ini
@@ -2,13 +2,16 @@
 pattern = "(00)(15)(65)([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.cfg"
 scopeid = "$1-$2-$3-$4-$5-$6"
 template = "tmpl_phone"
+content_type = "text/plain; charset=utf-8"
 
 [yealink-MAC-2]
 pattern = "(80)(5e)(0c)([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.cfg"
 scopeid = "$1-$2-$3-$4-$5-$6"
 template = "tmpl_phone"
+content_type = "text/plain; charset=utf-8"
 
 [yealink-MAC-3]
 pattern = "(80)(5e)(c0)([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.cfg"
 scopeid = "$1-$2-$3-$4-$5-$6"
 template = "tmpl_phone"
+content_type = "text/plain; charset=utf-8"

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -24,7 +24,6 @@ $container['storage'] = function($c) {
 $app->get('/{token}/{filename}', function(Request $request, Response $response, array $args) use ($app) {
     $this->logger->debug($request->getMethod() ." " . $request->getUri() . " " . json_encode($request->getParsedBody()) . " " . $_SERVER['HTTP_USER_AGENT']);
     global $config;
-    $logger = new \Monolog\Logger('Tancredi');
     $filename = $args['filename'];
     $token = $args['token'];
     $this->logger->info('Received a token and file request. Token: ' .$token . '. File: ' . $filename);

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -83,6 +83,7 @@ $app->get('/{token}/{filename}', function(Request $request, Response $response, 
             $loader = new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/');
         }
         $twig = new \Twig\Environment($loader,['autoescape' => false]);
+        $response = $response->withHeader('Cache-Control', 'private');
         $response = $response->withHeader('Content-Type', $data['content_type']);
         $response->getBody()->write($twig->render($template, $scope_data));
         $this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok '. __FILE__.':'.__LINE__);
@@ -155,6 +156,7 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
         // Load twig template
         $loader = new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/');
         $twig = new \Twig\Environment($loader,['autoescape' => false]);
+        $response = $response->withHeader('Cache-Control', 'private');
         $response = $response->withHeader('Content-Type', $data['content_type']);
         $response->getBody()->write($twig->render($template, $scope_data));
         $this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok ' . __FILE__.':'.__LINE__);

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -83,8 +83,9 @@ $app->get('/{token}/{filename}', function(Request $request, Response $response, 
             $loader = new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/');
         }
         $twig = new \Twig\Environment($loader,['autoescape' => false]);
-        $response = $response->getBody()->write($twig->render($template,$scope_data));
-	$this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok '. __FILE__.':'.__LINE__);
+        $response = $response->withHeader('Content-Type', $data['content_type']);
+        $response->getBody()->write($twig->render($template, $scope_data));
+        $this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok '. __FILE__.':'.__LINE__);
         return $response;
     } catch (Exception $e) {
         $this->logger->error($e->getMessage());
@@ -154,9 +155,10 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
         // Load twig template
         $loader = new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/');
         $twig = new \Twig\Environment($loader,['autoescape' => false]);
-	$response = $response->getBody()->write($twig->render($template,$scope_data));
-	$this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok ' . __FILE__.':'.__LINE__);
-	return $response;
+        $response = $response->withHeader('Content-Type', $data['content_type']);
+        $response->getBody()->write($twig->render($template, $scope_data));
+        $this->logger->debug($request->getMethod() ." " . $request->getUri() .' Result: 200 ok ' . __FILE__.':'.__LINE__);
+        return $response;
     } catch (Exception $e) {
         $this->logger->error($e->getMessage());
         $response = $response->withStatus(500);
@@ -178,6 +180,7 @@ function getDataFromFilename($filename,$logger) {
             $result['template'] = $pattern['template'];
             $logger->debug($pattern['pattern'].' '.$pattern['scopeid'] .' '.  $filename);
             $result['scopeid'] = preg_replace('/'.$pattern['pattern'].'/', $pattern['scopeid'] , $filename );
+            $result['content_type'] = empty($pattern['content_type']) ? 'text/plain; charset=utf-8' : $pattern['content_type'];
             break;
         }
     }


### PR DESCRIPTION
1. Configure the HTTP response `Content-Type` header in `patterns.d/`.
2. Send a `Cache-Control: private` header to prevent web proxies from caching the response