### PR TITLE
Remove builtin metadata_ vars

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -90,7 +90,6 @@ static.network.internet_port.type = 0
 #######################################################################################
 ##                               Network Advanced                                    ##
 #######################################################################################
-static.network.dhcp_host_name = {{ model }}-{{ metadata_scopeId|replace({'-':''}) }}
 static.network.dhcp.option60type = 0
 static.network.mtu_value = 1500
 static.network.qos.audiotos = 46

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -68,11 +68,6 @@ class Scope {
        $parents_vars = $this->getParentsVariables();
        $var_arrays[] = $parents_vars;
        $var_arrays[] = $this->data;
-       // Add metadata informations
-       $var_arrays[] = array(
-           'metadata_scopeType' => $this->metadata['scopeType'],
-           'metadata_scopeId' => $this->id,
-           );
        return call_user_func_array('array_merge', $var_arrays);
     }
 


### PR DESCRIPTION
If we really need some builtin information we can add it in Scope::getPhoneScope() function.