### PR TITLE
Remove the obsolete dhcp_enable variable

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -652,7 +652,7 @@ Download Server IP :{{ hostname }}
 Download Protocol  :{{ fanvil.scheme_map(provisioning_url_scheme) }}
 Download Mode      :1
 Download Interval  :1
-DHCP Option        :{{ dhcp_enable ? '66' : '0' }}
+DHCP Option        :0
 Save DHCP Opion    :0
 DHCP Option 120    :0
 PNP Enable         :0

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -864,7 +864,7 @@ PNP Port           :5060
 PNP Transport      :0
 PNP Interval       :1
 --Net Option--     :
-DHCP Option        :{{ dhcp_enable ? '66' : '0' }}
+DHCP Option        :0
 DHCPv6 Option      :0
 Dhcp Option 120    :0
 

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -48,7 +48,7 @@
 
         <screen_saver_timeout perm="">{{ screensaver_wait_time }}</screen_saver_timeout>
         <custom_bg_image_url perm="">{{ wallpaper_url }}</custom_bg_image_url>
-        <dhcp perm="">{{ dhcp_enable ? 'on' : 'off' }}</dhcp>
+        <dhcp perm="">on</dhcp>
         <dhcp_v6 perm="">off</dhcp_v6>
 
         {% if dss_transfer == 1 %}

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -118,7 +118,7 @@ static.network.lldp.packet_interval = 60
 #######################################################################################
 ##                                   Network VLAN                                    ##
 #######################################################################################
-static.network.vlan.dhcp_enable = {{ vlan_dhcp_enable|default('1') }}
+static.network.vlan.dhcp_enable = 1
 static.network.vlan.dhcp_option = {{ vlan_dhcp_option|default('132') }}
 static.network.vlan.vlan_change.enable = 0
 
@@ -188,7 +188,7 @@ static.auto_provision.repeat.minutes = 1440
 ##                                   Autop DHCP                                      ##
 #######################################################################################
 static.auto_provision.dhcp_option.list_user_options =
-static.auto_provision.dhcp_option.enable = {{ dhcp_enable }}
+static.auto_provision.dhcp_option.enable = 0
 
 ##V83 Add
 static.auto_provision.dhcp_option.list_user6_options =


### PR DESCRIPTION
Use DHCP provisioning redirect only at first boot. Then always rely on
static URL.

This setting pairs with https://github.com/nethesis/nethserver-nethvoice/pull/112

Tested with Fanvil X3 - OK