### PR TITLE
Fallback template and scope rules

### DIFF
--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,6 +4,7 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
+phone_tmpl = "fallback.tmpl"
 hostname =
 provisioning_url_scheme = "http"
 sip_tls_port = 5061

--- a/data/scopes/fanvil-X3.ini
+++ b/data/scopes/fanvil-X3.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Fanvil X3"
 

--- a/data/scopes/fanvil-X4.ini
+++ b/data/scopes/fanvil-X4.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Fanvil X4"
 

--- a/data/scopes/fanvil-X5.ini
+++ b/data/scopes/fanvil-X5.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Fanvil X5"
 

--- a/data/scopes/fanvil-X6.ini
+++ b/data/scopes/fanvil-X6.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Fanvil X6"
 

--- a/data/scopes/gigaset-Maxwell2.ini
+++ b/data/scopes/gigaset-Maxwell2.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Gigaset Maxwell 2"
 

--- a/data/scopes/gigaset-Maxwell3.ini
+++ b/data/scopes/gigaset-Maxwell3.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Gigaset Maxwell 3"
 

--- a/data/scopes/gigaset-MaxwellBasic.ini
+++ b/data/scopes/gigaset-MaxwellBasic.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Gigaset Maxwell Basic"
 

--- a/data/scopes/sangoma-S205.ini
+++ b/data/scopes/sangoma-S205.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S205"
 

--- a/data/scopes/sangoma-S206.ini
+++ b/data/scopes/sangoma-S206.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S206"
 

--- a/data/scopes/sangoma-S300.ini
+++ b/data/scopes/sangoma-S300.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S300"
 

--- a/data/scopes/sangoma-S305.ini
+++ b/data/scopes/sangoma-S305.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S305"
 

--- a/data/scopes/sangoma-S400.ini
+++ b/data/scopes/sangoma-S400.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S400"
 

--- a/data/scopes/sangoma-S405.ini
+++ b/data/scopes/sangoma-S405.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S405"
 

--- a/data/scopes/sangoma-S406.ini
+++ b/data/scopes/sangoma-S406.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S406"
 

--- a/data/scopes/sangoma-S500.ini
+++ b/data/scopes/sangoma-S500.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S500"
 

--- a/data/scopes/sangoma-S505.ini
+++ b/data/scopes/sangoma-S505.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S505"
 

--- a/data/scopes/sangoma-S700.ini
+++ b/data/scopes/sangoma-S700.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S700"
 

--- a/data/scopes/sangoma-S705.ini
+++ b/data/scopes/sangoma-S705.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Sangoma S705"
 

--- a/data/scopes/snom-D120.ini
+++ b/data/scopes/snom-D120.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D120"
 

--- a/data/scopes/snom-D305.ini
+++ b/data/scopes/snom-D305.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D305"
 

--- a/data/scopes/snom-D315.ini
+++ b/data/scopes/snom-D315.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D315"
 

--- a/data/scopes/snom-D345.ini
+++ b/data/scopes/snom-D345.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D345"
 

--- a/data/scopes/snom-D375.ini
+++ b/data/scopes/snom-D375.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D375"
 

--- a/data/scopes/snom-D385.ini
+++ b/data/scopes/snom-D385.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D385"
 

--- a/data/scopes/snom-D710.ini
+++ b/data/scopes/snom-D710.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D710"
 

--- a/data/scopes/snom-D712.ini
+++ b/data/scopes/snom-D712.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D712"
 

--- a/data/scopes/snom-D715.ini
+++ b/data/scopes/snom-D715.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D715"
 

--- a/data/scopes/snom-D717.ini
+++ b/data/scopes/snom-D717.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D717"
 

--- a/data/scopes/snom-D725.ini
+++ b/data/scopes/snom-D725.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D725"
 

--- a/data/scopes/snom-D735.ini
+++ b/data/scopes/snom-D735.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D735"
 

--- a/data/scopes/snom-D745.ini
+++ b/data/scopes/snom-D745.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D745"
 

--- a/data/scopes/snom-D765.ini
+++ b/data/scopes/snom-D765.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D765"
 

--- a/data/scopes/snom-D785.ini
+++ b/data/scopes/snom-D785.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Snom D785"
 

--- a/data/scopes/yealink-T19P_E2.ini
+++ b/data/scopes/yealink-T19P_E2.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T19P E2"
 

--- a/data/scopes/yealink-T21P_E2.ini
+++ b/data/scopes/yealink-T21P_E2.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T21P E2"
 

--- a/data/scopes/yealink-T23G.ini
+++ b/data/scopes/yealink-T23G.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T23G"
 

--- a/data/scopes/yealink-T27G.ini
+++ b/data/scopes/yealink-T27G.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T27G"
 

--- a/data/scopes/yealink-T29G.ini
+++ b/data/scopes/yealink-T29G.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T29G"
 

--- a/data/scopes/yealink-T40PG.ini
+++ b/data/scopes/yealink-T40PG.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T40P/G"
 

--- a/data/scopes/yealink-T41PS.ini
+++ b/data/scopes/yealink-T41PS.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T41P/S"
 

--- a/data/scopes/yealink-T42GS.ini
+++ b/data/scopes/yealink-T42GS.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T42G/S"
 

--- a/data/scopes/yealink-T46GS.ini
+++ b/data/scopes/yealink-T46GS.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T46G/S"
 

--- a/data/scopes/yealink-T48GS.ini
+++ b/data/scopes/yealink-T48GS.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T48G/S"
 

--- a/data/scopes/yealink-T49G.ini
+++ b/data/scopes/yealink-T49G.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T49G"
 

--- a/data/scopes/yealink-T53.ini
+++ b/data/scopes/yealink-T53.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T53"
 

--- a/data/scopes/yealink-T54.ini
+++ b/data/scopes/yealink-T54.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T54"
 

--- a/data/scopes/yealink-T56.ini
+++ b/data/scopes/yealink-T56.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T56"
 

--- a/data/scopes/yealink-T57.ini
+++ b/data/scopes/yealink-T57.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T57"
 

--- a/data/scopes/yealink-T58.ini
+++ b/data/scopes/yealink-T58.ini
@@ -1,5 +1,4 @@
 [metadata]
-inheritFrom = "defaults"
 scopeType = "model"
 displayName = "Yealink T58"
 

--- a/data/templates/fallback.tmpl
+++ b/data/templates/fallback.tmpl
@@ -1,0 +1,15 @@
+{%- if provisioning_user_agent starts with 'Fanvil X3' -%}
+{% include 'fanvil-X3.tmpl' %}
+{%- elseif provisioning_user_agent starts with 'Fanvil X5' -%}
+{% include 'fanvil-X5.tmpl' %}
+{%- elseif provisioning_user_agent matches '/snomD?\d+-SIP/' -%}
+{% include 'snom.tmpl' %}
+{%- elseif provisioning_user_agent starts with 'Yealink SIP' -%}
+{% include 'yealink.tmpl' %}
+{%- elseif provisioning_user_agent starts with 'Sangoma' -%}
+{% include 'sangoma.tmpl' %}
+{%- elseif provisioning_user_agent starts with 'Maxwell' -%}
+{% include 'gigaset-Maxwell.tmpl' %}
+{%- else -%}
+{{ throw.error() }}
+{%- endif -%}

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -111,7 +111,7 @@ $app->post('/phones', function (Request $request, Response $response, $args) {
     }
     $scope = new \Tancredi\Entity\Scope($mac, $this->storage, $this->logger);
     $scope->metadata['displayName'] = $display_name;
-    $scope->metadata['inheritFrom'] = (empty($model) ? 'defaults' : $model);
+    $scope->metadata['inheritFrom'] = $model;
     $scope->metadata['scopeType'] = "phone";
     $scope->setVariables($variables);
     \Tancredi\Entity\TokenManager::createToken(uniqid($prefix = rand(), $more_entropy = TRUE), $mac , TRUE); // create first time access token
@@ -310,7 +310,6 @@ $app->post('/models', function (Request $request, Response $response, $args) {
     }
     $scope = new \Tancredi\Entity\Scope($id, $this->storage, $this->logger);
     $scope->metadata['displayName'] = $display_name;
-    $scope->metadata['inheritFrom'] = 'defaults';
     $scope->metadata['scopeType'] = "model";
     $scope->setVariables($variables);
     $response = $response->withJson(getModelScope($id, $this->storage, $this->logger),201,JSON_FLAGS);

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -156,11 +156,10 @@ $app->get('/{filename}', function(Request $request, Response $response, array $a
 
 function renderTwigTemplate($template, $scope_data) {
     global $config;
-    if (file_exists($config['rw_dir'] . 'templates-custom/' . $template)) {
-        $loader = new \Twig\Loader\FilesystemLoader($config['rw_dir'] . 'templates-custom/');
-    } else {
-        $loader = new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/');
-    }
+    $loader = new \Twig\Loader\ChainLoader([
+        new \Twig\Loader\FilesystemLoader($config['rw_dir'] . 'templates-custom/'),
+        new \Twig\Loader\FilesystemLoader($config['ro_dir'] . 'templates/'),
+    ]);
     $twig = new \Twig\Environment($loader,['autoescape' => false]);
     $payload = $twig->render($template, $scope_data);
     return $payload;

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -43,7 +43,7 @@ class Scope {
             $parent = $this->metadata['inheritFrom'];
         }
 
-        while (!empty($parent) && $parent !== null) {
+        while (!empty($parent) && $parent !== 'defaults') {
             $variables = $this->storage->storageRead($parent);
             if (array_key_exists('metadata',$variables) and array_key_exists('inheritFrom',$variables['metadata'])) {
                 $parent = $variables['metadata']['inheritFrom'];
@@ -54,6 +54,8 @@ class Scope {
                 $var_arrays[] = $variables['data'];
             }
         }
+        $variables = $this->storage->storageRead('defaults');
+        $var_arrays[] = $variables['data'];
         $var_arrays = array_reverse($var_arrays);
         if (!empty($var_arrays)) {
             return call_user_func_array('array_merge', $var_arrays);


### PR DESCRIPTION
- Fallback Template, used if the phone scope is not associated with a model. It loads the correct template  on the User Agent basis
- Always try to load templates from both rw and ro dirs in a non-exclusive manner
- Clean up unnecessary relations with the defaults scope
