### PR TITLE
Fanvil provisioning complete

### DIFF
--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -7,6 +7,7 @@ displayName = ""
 tmpl_phone = "fallback.tmpl"
 hostname =
 provisioning_url_scheme = "http"
+provisioning_freq = "everyday"
 sip_tls_port = 5061
 sip_udp_port = 5060
 ringtone = 1

--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -692,8 +692,8 @@ Config File Key    :
 Common Cfg File Key:
 Download Server IP :{{ hostname }}
 Download Protocol  :{{ fanvil.scheme_map(provisioning_url_scheme) }}
-Download Mode      :{{ provisioning_freq == 'never' ? '1' : '2' }}
-Download Interval  :{{ fanvil.upgrade_wait_hours(timezone) }}
+Download Mode      :{{ (provisioning_complete and provisioning_freq == 'never') ? '1' : '2' }}
+Download Interval  :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone) : '1' }}
 DHCP Option        :0
 Save DHCP Opion    :0
 DHCP Option 120    :0

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -900,8 +900,8 @@ Check FailTimes    :5
 Flash Server IP    :{{ hostname }}
 Flash File Name    :{{ 'http' in provisioning_url_scheme ? (provisioning_url_path | trim('/', 'left') ~ tok2 ~ '/$mac.cfg') : '$mac.cfg' }}
 Flash Protocol     :{{ fanvil.scheme_map(provisioning_url_scheme) }}
-Flash Mode         :{{ provisioning_freq == 'never' ? '1' : '2' }}
-Flash Interval     :{{ fanvil.upgrade_wait_hours(timezone) }}
+Flash Mode         :{{ (provisioning_complete and provisioning_freq == 'never') ? '1' : '2' }}
+Flash Interval     :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone) : '1' }}
 update PB Interval :720
 AP Pswd Encryption :0
 --Sip Pnp List--   :


### PR DESCRIPTION
- Set a default  for all brands for `provisioning_freq` variable
- For Fanvil phones, reload the configuration with url2 just after 1 hour. By now it waits until the next night...