### PR TITLE
New cap_ldap_tls_blacklist variable

### DIFF
--- a/data/patterns.d/variables.ini
+++ b/data/patterns.d/variables.ini
@@ -1,0 +1,5 @@
+[variables]
+pattern = "variables\.md"
+template = "tmpl_variables"
+scopeid = ""
+content_type = "text/plain; charset=utf-8"

--- a/data/scopes/defaults.ini
+++ b/data/scopes/defaults.ini
@@ -4,6 +4,7 @@ scopeType = "defaults"
 displayName = ""
 
 [data]
+cap_ldap_tls_blacklist = starttls
 tmpl_phone = "fallback.tmpl"
 hostname =
 provisioning_url_scheme = "http"

--- a/data/scopes/fanvil-X3.ini
+++ b/data/scopes/fanvil-X3.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Fanvil X3"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X3.tmpl"
 cap_linekey_count = 2

--- a/data/scopes/fanvil-X4.ini
+++ b/data/scopes/fanvil-X4.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Fanvil X4"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X3.tmpl"
 cap_linekey_count = 30

--- a/data/scopes/fanvil-X5.ini
+++ b/data/scopes/fanvil-X5.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Fanvil X5"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 cap_linekey_count = 40

--- a/data/scopes/fanvil-X6.ini
+++ b/data/scopes/fanvil-X6.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Fanvil X6"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 cap_linekey_count = 60

--- a/data/scopes/gigaset-Maxwell2.ini
+++ b/data/scopes/gigaset-Maxwell2.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Gigaset Maxwell 2"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count = 8

--- a/data/scopes/gigaset-Maxwell3.ini
+++ b/data/scopes/gigaset-Maxwell3.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Gigaset Maxwell 3"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count = 8

--- a/data/scopes/gigaset-Maxwell4.ini
+++ b/data/scopes/gigaset-Maxwell4.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Gigaset Maxwell 4"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count = 8

--- a/data/scopes/gigaset-MaxwellBasic.ini
+++ b/data/scopes/gigaset-MaxwellBasic.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Gigaset Maxwell Basic"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = "%25MACD.xml"
 tmpl_phone = "gigaset-Maxwell.tmpl"
 cap_linekey_count =

--- a/data/scopes/sangoma-S205.ini
+++ b/data/scopes/sangoma-S205.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S205"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count =
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S206.ini
+++ b/data/scopes/sangoma-S206.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S206"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 2
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S300.ini
+++ b/data/scopes/sangoma-S300.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S300"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count =
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S305.ini
+++ b/data/scopes/sangoma-S305.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S305"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 4
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S400.ini
+++ b/data/scopes/sangoma-S400.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S400"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 6
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S405.ini
+++ b/data/scopes/sangoma-S405.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S405"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 6
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S406.ini
+++ b/data/scopes/sangoma-S406.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S406"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 6
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S500.ini
+++ b/data/scopes/sangoma-S500.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S500"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 8
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S505.ini
+++ b/data/scopes/sangoma-S505.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S505"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 8
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S700.ini
+++ b/data/scopes/sangoma-S700.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S700"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 10
 cap_linekey_type_blacklist =

--- a/data/scopes/sangoma-S705.ini
+++ b/data/scopes/sangoma-S705.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Sangoma S705"
 
 [data]
+cap_ldap_tls_blacklist = starttls,ldaps
 tmpl_phone = "sangoma.tmpl"
 cap_linekey_count = 10
 cap_linekey_type_blacklist =

--- a/data/scopes/snom-D120.ini
+++ b/data/scopes/snom-D120.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D120"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 2

--- a/data/scopes/snom-D305.ini
+++ b/data/scopes/snom-D305.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D305"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5

--- a/data/scopes/snom-D315.ini
+++ b/data/scopes/snom-D315.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D315"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5

--- a/data/scopes/snom-D345.ini
+++ b/data/scopes/snom-D345.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D345"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 48

--- a/data/scopes/snom-D375.ini
+++ b/data/scopes/snom-D375.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D375"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 12

--- a/data/scopes/snom-D385.ini
+++ b/data/scopes/snom-D385.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D385"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 48

--- a/data/scopes/snom-D710.ini
+++ b/data/scopes/snom-D710.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D710"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5

--- a/data/scopes/snom-D712.ini
+++ b/data/scopes/snom-D712.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D712"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5

--- a/data/scopes/snom-D715.ini
+++ b/data/scopes/snom-D715.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D715"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 5

--- a/data/scopes/snom-D717.ini
+++ b/data/scopes/snom-D717.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D717"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 3

--- a/data/scopes/snom-D725.ini
+++ b/data/scopes/snom-D725.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D725"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 18

--- a/data/scopes/snom-D735.ini
+++ b/data/scopes/snom-D735.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D735"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 32

--- a/data/scopes/snom-D745.ini
+++ b/data/scopes/snom-D745.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D745"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 32

--- a/data/scopes/snom-D765.ini
+++ b/data/scopes/snom-D765.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D765"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 16

--- a/data/scopes/snom-D785.ini
+++ b/data/scopes/snom-D785.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Snom D785"
 
 [data]
+cap_ldap_tls_blacklist = starttls
 provisioning_url_filename = "{mac}.xml"
 tmpl_phone = "snom.tmpl"
 cap_linekey_count = 24

--- a/data/scopes/yealink-T19P_E2.ini
+++ b/data/scopes/yealink-T19P_E2.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T19P E2"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 0

--- a/data/scopes/yealink-T21P_E2.ini
+++ b/data/scopes/yealink-T21P_E2.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T21P E2"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 2

--- a/data/scopes/yealink-T23G.ini
+++ b/data/scopes/yealink-T23G.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T23G"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 3

--- a/data/scopes/yealink-T27G.ini
+++ b/data/scopes/yealink-T27G.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T27G"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 21

--- a/data/scopes/yealink-T29G.ini
+++ b/data/scopes/yealink-T29G.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T29G"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 27

--- a/data/scopes/yealink-T40PG.ini
+++ b/data/scopes/yealink-T40PG.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T40P/G"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 3

--- a/data/scopes/yealink-T41PS.ini
+++ b/data/scopes/yealink-T41PS.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T41P/S"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 15

--- a/data/scopes/yealink-T42GS.ini
+++ b/data/scopes/yealink-T42GS.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T42G/S"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 15

--- a/data/scopes/yealink-T46GS.ini
+++ b/data/scopes/yealink-T46GS.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T46G/S"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 27

--- a/data/scopes/yealink-T48GS.ini
+++ b/data/scopes/yealink-T48GS.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T48G/S"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 29

--- a/data/scopes/yealink-T49G.ini
+++ b/data/scopes/yealink-T49G.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T49G"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 4

--- a/data/scopes/yealink-T53.ini
+++ b/data/scopes/yealink-T53.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T53"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 21

--- a/data/scopes/yealink-T54.ini
+++ b/data/scopes/yealink-T54.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T54"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 27

--- a/data/scopes/yealink-T56.ini
+++ b/data/scopes/yealink-T56.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T56"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 27

--- a/data/scopes/yealink-T57.ini
+++ b/data/scopes/yealink-T57.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T57"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 29

--- a/data/scopes/yealink-T58.ini
+++ b/data/scopes/yealink-T58.ini
@@ -3,6 +3,7 @@ scopeType = "model"
 displayName = "Yealink T58"
 
 [data]
+cap_ldap_tls_blacklist =
 provisioning_url_filename = 
 tmpl_phone = 'yealink.tmpl'
 cap_linekey_count = 27

--- a/data/templates/sangoma.tmpl
+++ b/data/templates/sangoma.tmpl
@@ -158,7 +158,7 @@
         <P5430 para="LDAP.NameFilter">{{ ldap_name_filter }}</P5430>
         <P5431 para="LDAP.NumberFilter">{{ ldap_number_filter }}</P5431>
         <P5432 para="LDAP.ServerAddress">{{ ldap_server | default(hostname) }}</P5432>
-        <P5433 para="LDAP.Port">{{ ldap_port | default( ldap_tls == 'ldaps' ? '636' : '389' ) }}</P5433>
+        <P5433 para="LDAP.Port">{{ ldap_port | default('389') }}</P5433>
         <P5434 para="LDAP.Base">{{ ldap_base }}</P5434>
         <P5435 para="LDAP.UserName">{{ ldap_user }}</P5435>
         <P5436 para="LDAP.Password">{{ ldap_password }}</P5436>

--- a/data/templates/variables.macros
+++ b/data/templates/variables.macros
@@ -1,0 +1,5 @@
+{% macro allowed_values(varname) %}
+{% set av = {
+    'hostname': ['String', 'The provisioning server DNS name or IP address']
+} %}
+{% endmacro allowed_values %}

--- a/data/templates/variables.tmpl
+++ b/data/templates/variables.tmpl
@@ -1,0 +1,11 @@
+# Variables
+{% import 'variables.macros' as variables %}
+
+{% for key in _context|keys|sort %}
+## {{ key }}
+
+Current value: {{ _context[key] }}
+
+Allowed values:
+
+{% endfor %}


### PR DESCRIPTION
Snom and Sangoma phones do not support every possible `ldap_tls` value. This PR defines a new `cap_ldap_tls_blacklist` so the UI can hide unsupported protocols.