### PR TITLE
Fix Twig syntax for Gigaset template

### DIFF
--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -15,8 +15,8 @@
     <param name="System.DateAndTime.DateOrder" value="{{ gigaset.date_format(date_format) }}" />
 
     <param name="Telephony.ToneScheme" value="{{ gigaset.tones_code(tonezone) }}" />
-    <param name="Telephony.CallTransfer.HoldOnTransfer.Attended" value="{{ dss_transfer != 'attended' ? 'Disabled : 'Enabled' }}" />
-    <param name="Telephony.CallTransfer.HoldOnTransfer.Unattended" value="{{ dss_transfer == 'attended' ? 'Disabled : 'Enabled' }}" />
+    <param name="Telephony.CallTransfer.HoldOnTransfer.Attended" value="{{ dss_transfer != 'attended' ? 'Disabled' : 'Enabled' }}" />
+    <param name="Telephony.CallTransfer.HoldOnTransfer.Unattended" value="{{ dss_transfer == 'attended' ? 'Disabled' : 'Enabled' }}" />
     <param name="PhoneUI.Settings.Language" value="{{ gigaset.language_code(language) }}" />
     <param name="WebUI.Language" value="{{ gigaset.language_code(language) }}" />
     


### PR DESCRIPTION
The current template gives back a 500 error.

    [2020-03-30 10:49:23] Tancredi.ERROR: Unexpected token "name" of value "Enabled" ("end of print statement" expected). [] []
