### PR TITLE
Fix Yealink T23P TLS error 218910881

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2305,3 +2305,9 @@ static.security.user_password = var:{{ varpw }}
 static.security.user_name.var = var
 static.security.user_name.admin = admin
 static.security.user_name.user = user
+
+{% if provisioning_user_agent matches '/SIP-T23P 44\.8[4-9]\./' %}
+# Fix TLS error 218910881 (ASN1_item_verify-unknown message digest algorithm)
+sip.tls_cipher_list=!ECDH:AES:!ADH:!LOW:!NULL
+security.tls_cipher_list =!ECDH:AES:!ADH:!LOW:!NULL
+{% endif %}


### PR DESCRIPTION
The old Yealink models have a builtin certificate with MD5 signature. 
MD5 is now disabled in modern SSL libraries. This fix disables the 
cipher that triggers the client certificate exchange.

This is the full log error line:

    SSL SSL_ERROR_SSL (Read): Level: 0 err: <218910881> <asn1 encoding routines-ASN1_item_verify-unknown message digest algorithm>