### PR TITLE
Set "var" user password

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2299,9 +2299,9 @@ expansion_module.{{ module }}.key.{{ number }}.xml_phonebook = %NULL%
 #######################################################################################
 ##                               Security                                            ##
 #######################################################################################
-static.security.user_password = admin:{{ adminpw | default('admin') }}
-static.security.user_password = user:{{ userpw | default('1234') }}
-static.security.user_password = var:{{ varpw }}
-static.security.user_name.var = var
 static.security.user_name.admin = admin
+static.security.user_password = admin:{{ adminpw | default('admin') }}
 static.security.user_name.user = user
+static.security.user_password = user:{{ userpw | default('1234') }}
+static.security.user_name.var = var
+static.security.user_password = var:{{ userpw | default('1234') }}


### PR DESCRIPTION
Use the same password of "user". The "varpw" password is never defined in Tancredi.