### PR TITLE
Update snom.tmpl - http password

### DIFF
--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -153,8 +153,6 @@
         <lcserver1 perm=""></lcserver1>
         <http_proxy perm=""></http_proxy>
         <http_port perm=""></http_port>
-        <http_user perm=""></http_user>
-        <http_pass perm=""></http_pass>
         <http_scheme perm="">on</http_scheme>
         <https_port perm="">443</https_port>
         <webserver_type perm="">http_https</webserver_type>


### PR DESCRIPTION
Problema, http password non viene settata in fase di provisioning
Alla linea 61 viene impostata la password di admin e di http_user
Ho verificato che alla riga 156 veniva resettata.
Eliminata la riga  156 e 157
Ora la password viene correttamente impostata in provisioning

----

Problem, http password is not set during provisioning
On line 61 the password for admin and http_user is set
I verified that on line 156 it was reset.
Row 156 and 157 deleted
The password is now correctly set in provisioning