### PR TITLE
Disable Yealink https web UI

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -100,7 +100,7 @@ static.network.port.max_rtpport = 12780
 static.network.qos.signaltos = 26
 
 static.wui.http_enable = 1
-static.wui.https_enable = 1
+static.wui.https_enable = 0
 static.network.port.https = 443
 static.network.port.http = 80
 


### PR DESCRIPTION
If both are enabled, the phone always redirects the browser to https. We prefer to use port 80 like other vendors.