### PR TITLE
Selectable log handler and verbosity

### DIFF
--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -9,25 +9,9 @@ use \Psr\Http\Message\ResponseInterface as Response;
 
 $app = new \Slim\App;
 $container = $app->getContainer();
+$container['config'] = $config;
 $container['logger'] = function($c) {
-    global $config;
-    $logger = new \Monolog\Logger('tancredi');
-    $handler = new \Monolog\Handler\ErrorLogHandler();
-    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%");
-    $handler->setFormatter($formatter);
-
-    if($config['loglevel'] == 'ERROR') {
-        $handler->setLevel($logger::ERROR);
-    } elseif ($config['loglevel'] == 'WARNING') {
-        $handler->setLevel($logger::WARNING);
-    } elseif ($config['loglevel'] == 'INFO') {
-        $handler->setLevel($logger::INFO);
-    } else {
-        $handler->setLevel($logger::DEBUG);
-    }
-
-    $logger->pushHandler($handler);
-    return $logger;
+    return \Tancredi\LoggerFactory::createLogger($c);
 };
 
 $container['storage'] = function($c) {

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -13,7 +13,7 @@ $container['logger'] = function($c) {
     global $config;
     $logger = new \Monolog\Logger('tancredi');
     $handler = new \Monolog\Handler\ErrorLogHandler();
-    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%\n");
+    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%");
     $handler->setFormatter($formatter);
 
     if($config['loglevel'] == 'ERROR') {

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -11,9 +11,22 @@ $app = new \Slim\App;
 $container = $app->getContainer();
 $container['logger'] = function($c) {
     global $config;
-    $logger = new \Monolog\Logger('Tancredi');
-    $file_handler = new \Monolog\Handler\StreamHandler($config['logfile'],\Monolog\Logger::DEBUG); //TODO use config['log_level'] here somehow
-    $logger->pushHandler($file_handler);
+    $logger = new \Monolog\Logger('tancredi');
+    $handler = new \Monolog\Handler\ErrorLogHandler();
+    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%\n");
+    $handler->setFormatter($formatter);
+
+    if($config['loglevel'] == 'ERROR') {
+        $handler->setLevel($logger::ERROR);
+    } elseif ($config['loglevel'] == 'WARNING') {
+        $handler->setLevel($logger::WARNING);
+    } elseif ($config['loglevel'] == 'INFO') {
+        $handler->setLevel($logger::INFO);
+    } else {
+        $handler->setLevel($logger::DEBUG);
+    }
+
+    $logger->pushHandler($handler);
     return $logger;
 };
 

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -9,9 +9,22 @@ $app = new \Slim\App;
 $container = $app->getContainer();
 $container['logger'] = function($c) {
     global $config;
-    $logger = new \Monolog\Logger('Tancredi');
-    $file_handler = new \Monolog\Handler\StreamHandler($config['logfile'],\Monolog\Logger::DEBUG); //TODO use config['log_level'] here somehow
-    $logger->pushHandler($file_handler);
+    $logger = new \Monolog\Logger('tancredi');
+    $handler = new \Monolog\Handler\ErrorLogHandler();
+    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%\n");
+    $handler->setFormatter($formatter);
+
+    if($config['loglevel'] == 'ERROR') {
+        $handler->setLevel($logger::ERROR);
+    } elseif ($config['loglevel'] == 'WARNING') {
+        $handler->setLevel($logger::WARNING);
+    } elseif ($config['loglevel'] == 'INFO') {
+        $handler->setLevel($logger::INFO);
+    } else {
+        $handler->setLevel($logger::DEBUG);
+    }
+
+    $logger->pushHandler($handler);
     return $logger;
 };
 

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -7,25 +7,9 @@ use \Psr\Http\Message\ResponseInterface as Response;
 
 $app = new \Slim\App;
 $container = $app->getContainer();
+$container['config'] = $config;
 $container['logger'] = function($c) {
-    global $config;
-    $logger = new \Monolog\Logger('tancredi');
-    $handler = new \Monolog\Handler\ErrorLogHandler();
-    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%");
-    $handler->setFormatter($formatter);
-
-    if($config['loglevel'] == 'ERROR') {
-        $handler->setLevel($logger::ERROR);
-    } elseif ($config['loglevel'] == 'WARNING') {
-        $handler->setLevel($logger::WARNING);
-    } elseif ($config['loglevel'] == 'INFO') {
-        $handler->setLevel($logger::INFO);
-    } else {
-        $handler->setLevel($logger::DEBUG);
-    }
-
-    $logger->pushHandler($handler);
-    return $logger;
+    return \Tancredi\LoggerFactory::createLogger($c);
 };
 
 $container['storage'] = function($c) {

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -11,7 +11,7 @@ $container['logger'] = function($c) {
     global $config;
     $logger = new \Monolog\Logger('tancredi');
     $handler = new \Monolog\Handler\ErrorLogHandler();
-    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%\n");
+    $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%");
     $handler->setFormatter($formatter);
 
     if($config['loglevel'] == 'ERROR') {

--- a/src/LoggerFactory.php
+++ b/src/LoggerFactory.php
@@ -1,0 +1,58 @@
+<?php namespace Tancredi;
+
+/*
+ * Copyright (C) 2020 Nethesis S.r.l.
+ * http://www.nethesis.it - sviluppo@nethesis.it
+ *
+ * This script is part of Tancredi.
+ *
+ * Tancredi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * Tancredi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tancredi.  If not, see COPYING.
+ */
+
+/**
+ * Instantiate and configure a Monolog\Logger instancea
+ *
+ */
+class LoggerFactory 
+{
+    public static function createLogger(\ArrayAccess $dc)
+    {
+        $logger = new \Monolog\Logger('tancredi');
+
+        $config = $dc['config'];
+        if( ! empty($config['logfile'])) {
+            $handler = new \Monolog\Handler\StreamHandler($config['logfile']);
+        } else {
+            $handler = new \Monolog\Handler\ErrorLogHandler();
+            // We assume the error_log already adds a time stamp to log messages:
+            $formatter = new \Monolog\Formatter\LineFormatter("%channel%.%level_name%: %message% %context% %extra%");
+            $handler->setFormatter($formatter);
+        }
+
+        if($config['loglevel'] == 'ERROR') {
+            $handler->setLevel($logger::ERROR);
+        } elseif ($config['loglevel'] == 'WARNING') {
+            $handler->setLevel($logger::WARNING);
+        } elseif ($config['loglevel'] == 'INFO') {
+            $handler->setLevel($logger::INFO);
+        } else {
+            $handler->setLevel($logger::DEBUG);
+        }
+
+        $logger->pushHandler($handler);
+        \Monolog\ErrorHandler::register($logger);
+        return $logger;
+    }
+
+}

--- a/tancredi.conf.sample
+++ b/tancredi.conf.sample
@@ -5,8 +5,11 @@
 ;  - INFO
 ;  - WARNING
 ;  - ERROR
-; Log messages sent to error_log()
 loglevel = "DEBUG"
+
+; Write log entries to the given path. Ensure proper permissions are set.
+; If "logfile" is empty or not set, log messages are sent to PHP error_log.
+;logfile = "/var/log/tancredi/tancredi.log"
 
 ; Directory where Tancredi has Read/Write access
 rw_dir = "/usr/share/tancredi/data/"

--- a/tancredi.conf.sample
+++ b/tancredi.conf.sample
@@ -1,9 +1,11 @@
 ; Tancredi sample configuration file
 
-; Tancredi log file. Make sure user Tancredi run with (apache probably) has write permission
-logfile = "/var/log/tancredi.log"
-
-; Tancredi loglevel. Allowed levels are DEBUG,INFO,WARNING,ERROR
+; Tancredi log verbosity level. Allowed level names are
+;  - DEBUG (default)
+;  - INFO
+;  - WARNING
+;  - ERROR
+; Log messages sent to error_log()
 loglevel = "DEBUG"
 
 ; Directory where Tancredi has Read/Write access


### PR DESCRIPTION
- If `logfile` is not set or empty use the Monolog handler "ErrorLogHandler" which is based on error_log(). The log is sent through PHP APIs. See the PHP configuration "error_log" parameter.
- Fix the `loglevel` implementation
- Send PHP error/warning/info messages to the selected application log

nethesis/dev#5773