### PR TITLE
Snom HTTP admin UI password not set

### DIFF
--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -61,7 +61,7 @@
         <admin_mode_password perm="">{{ adminpw | default('admin') }}</admin_mode_password>
         <admin_mode_password_confirm perm="">{{ adminpw | default('admin') }}</admin_mode_password_confirm>
         <http_user perm="">admin</http_user>
-        <http_pass perm="">{{ adminpw | default('admin') }}</http_password>
+        <http_pass perm="">{{ adminpw | default('admin') }}</http_pass>
 
         <setting_server perm="RW">{{ provisioning_url2 }}</setting_server>
         {# snom allowed values: 3..15. active_backlight_level values: 1..10 #}

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -61,7 +61,7 @@
         <admin_mode_password perm="">{{ adminpw | default('admin') }}</admin_mode_password>
         <admin_mode_password_confirm perm="">{{ adminpw | default('admin') }}</admin_mode_password_confirm>
         <http_user perm="">admin</http_user>
-        <http_pass perm="">{{ adminpw | default('admin') }}</http_pass>
+        <http_pass perm="">{{ adminpw |  default('admin') }}</http_pass>
 
         <setting_server perm="RW">{{ provisioning_url2 }}</setting_server>
         {# snom allowed values: 3..15. active_backlight_level values: 1..10 #}

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -61,7 +61,7 @@
         <admin_mode_password perm="">{{ adminpw | default('admin') }}</admin_mode_password>
         <admin_mode_password_confirm perm="">{{ adminpw | default('admin') }}</admin_mode_password_confirm>
         <http_user perm="">admin</http_user>
-        <http_password perm="">{{ adminpw | default('admin') }}</http_password>
+        <http_pass perm="">{{ adminpw | default('admin') }}</http_password>
 
         <setting_server perm="RW">{{ provisioning_url2 }}</setting_server>
         {# snom allowed values: 3..15. active_backlight_level values: 1..10 #}
@@ -153,8 +153,6 @@
         <lcserver1 perm=""></lcserver1>
         <http_proxy perm=""></http_proxy>
         <http_port perm=""></http_port>
-        <http_user perm=""></http_user>
-        <http_pass perm=""></http_pass>
         <http_scheme perm="">on</http_scheme>
         <https_port perm="">443</https_port>
         <webserver_type perm="">http_https</webserver_type>


### PR DESCRIPTION
Alla riga 64 il tag vostro tag

    <http_password perm="">{{ adminpw | default('admin') }}</http_password>

In realtà il tag corretto sarebbe questo:

    <http_pass perm="">{{ adminpw | default('admin') }}</http_password>

Poi sempre nella riga 156 e 157 sono rimasti i tag che resettano l'utente e e la password che andrebbero eliminate