### PR TITLE
New short_mac readonly attribute

### DIFF
--- a/docs/phonesMacGet.md
+++ b/docs/phonesMacGet.md
@@ -15,6 +15,7 @@ Success response:
 ```json
 {
     "mac": "01-23-45-67-89-AB",
+    "short_mac": "0123456789ab",
     "model": "acme19.2",
     "display_name": "Acme",
     "tok1": "3cb63010-6e80-41ff-9437-c4b1413975db",

--- a/docs/phonesMacPatch.md
+++ b/docs/phonesMacPatch.md
@@ -41,6 +41,7 @@ Success response:
 ```json
 {
     "mac": "01-23-45-67-89-AB",
+    "short_mac": "0123456789ab",
     "model": "acme19.2-custom",
     "display_name": "Acme",
     "tok1": "3cb63010-6e80-41ff-9437-c4b1413975db",
@@ -61,7 +62,7 @@ can be changed accordingly.
 
 ## Read only attributes
 
-Attributes `mac`, `tok1`, `tok2`, `provisioning_url1`, `provisioning_url2` are
+Attributes `mac`, `short_mac`, `tok1`, `tok2`, `provisioning_url1`, `provisioning_url2` are
 read-only. Attempt to change their values causes the whole request to fail.
 
     PATCH /tancredi/api/v1/phones/01-23-45-67-89-AB
@@ -69,6 +70,7 @@ read-only. Attempt to change their values causes the whole request to fail.
 ```json
 {
     "mac": "doesn't work",
+    "short_mac": "doesn't work",
     "model_url": "doesn't work",
     "tok1": "doesn't work",
     "tok2": "doesn't work",

--- a/docs/phonesPost.md
+++ b/docs/phonesPost.md
@@ -8,6 +8,7 @@ properties are assigned automatically and must not be supplied:
 * `tok1`
 * `tok2`
 * `model_url`
+* `short_mac`
 
 
 ```text

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -135,7 +135,7 @@ $app->patch('/phones/{mac}', function (Request $request, Response $response, $ar
         return $response;
     }
 
-    $readonly_params = ['mac', 'model_url', 'tok1', 'tok2', 'provisioning_url1', 'provisioning_url2'];
+    $readonly_params = ['mac', 'short_mac', 'model_url', 'tok1', 'tok2', 'provisioning_url1', 'provisioning_url2'];
     if (array_intersect($readonly_params, array_keys($patch_data))) {
         $results = array(
             'type' => 'https://github.com/nethesis/tancredi/wiki/problems#read-only-attribute',

--- a/src/Entity/Scope.php
+++ b/src/Entity/Scope.php
@@ -123,9 +123,16 @@ class Scope {
         $scope = new \Tancredi\Entity\Scope($mac, $storage, $logger, null);
         $vars = $scope->getVariables();
 
+        $short_mac = strtolower(str_replace('-', '', $mac));
         $hostname = empty($vars['hostname']) ? gethostname() : $vars['hostname'];
         $provisioning_url_path = trim($config['provisioning_url_path'], '/') . '/';
         $provisioning_url_scheme = empty($vars['provisioning_url_scheme']) ? 'http' : $vars['provisioning_url_scheme'];
+        $provisioning_url_filename = strtr($vars['provisioning_url_filename'], [
+            '$mac' => $short_mac, // Fanvil
+            '%25MACD' => $short_mac, // Gigaset+urlencode
+            '%MACD' => $short_mac, // Gigaset
+            '{mac}' => $short_mac, // Snom
+        ]);
 
         if ($inherit) {
             $scope_data = $vars;
@@ -139,6 +146,7 @@ class Scope {
         $tok2 = \Tancredi\Entity\TokenManager::getToken2($mac);
         $results = array(
             'mac' => $mac,
+            'short_mac' => $short_mac,
             'model' => $scope->metadata['inheritFrom'],
             'display_name' => $scope->metadata['displayName'],
             'tok1' => $tok1,
@@ -148,12 +156,12 @@ class Scope {
         );
 
         if($tok1 && $provisioning_url_scheme && $hostname) {
-            $results['provisioning_url1'] = trim("{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok1}/{$vars['provisioning_url_filename']}", '/');
+            $results['provisioning_url1'] = trim("{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok1}/{$provisioning_url_filename}", '/');
         } else {
             $results['provisioning_url1'] = NULL;
         }
         if($tok2 && $provisioning_url_scheme && $hostname) {
-            $results['provisioning_url2'] = trim("{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok2}/{$vars['provisioning_url_filename']}", '/');
+            $results['provisioning_url2'] = trim("{$provisioning_url_scheme}://{$hostname}/{$provisioning_url_path}{$tok2}/{$provisioning_url_filename}", '/');
         } else {
             // Never return back an invalid provisioning URL!
             throw new \LogicException(sprintf("%s - malformed provisioning_url2", 1582905675));


### PR DESCRIPTION
Substitute the `short_mac` value in the `provisioning_url1` and 
`provisioning_url2` variables automatically. 

![image](https://user-images.githubusercontent.com/2920838/80013101-a2579680-84ce-11ea-9fe4-56dd7229226b.png)

Also push the new `short_mac` value in the Twig context to reuse it in 
templates, if wanted.