### PR TITLE
Avoid filename subtring pattern matching

### DIFF
--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -202,7 +202,7 @@ function getDataFromFilename($filename,$logger) {
         $patterns = array_merge($patterns, parse_ini_file($pattern_file, true));
     }
     foreach ($patterns as $pattern_name => $pattern) {
-        if (preg_match('/'.$pattern['pattern'].'/', $filename, $tmp)) {
+        if (preg_match('/^'.$pattern['pattern'].'$/', $filename, $tmp)) {
             $result['pattern_name'] = $pattern_name;
             $result['template'] = $pattern['template'];
             $result['scopeid'] = preg_replace('/'.$pattern['pattern'].'/', $pattern['scopeid'] , $filename );


### PR DESCRIPTION
Force the patterns to match the whole string.

Snom phones send requests like

    80.17.99.73 - - [29/Apr/2020:01:11:12 +0200] "GET /provisioning/11144772565e7e38c9a5af9/000413821a63.xml HTTP/1.1" 200 49218
    80.17.99.73 - - [29/Apr/2020:01:11:15 +0200] "GET /provisioning/11144772565e7e38c9a5af9/000413821a63-000413821A63.xml HTTP/1.1" 200 49218