### PR TITLE
Fix Fanvil linekey type "line"

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -637,7 +637,7 @@ Fkey{{ index }} Value              :F_LDAP:1
 Fkey{{ index }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Phonebook', language)) | slice(0,10)  }}
 {% elseif _context['linekey_type_' ~ index] == 'line' %}
 Fkey{{ index }} Type               :2
-Fkey{{ index }} Value              :SIP{{ index }}
+Fkey{{ index }} Value              :SIP1
 Fkey{{ index }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Line %s', language) | format(index)) | slice(0,10) }}
 {% elseif _context['linekey_type_' ~ index] == 'multicast_paging' %}
 Fkey{{ index }} Type               :14

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -778,7 +778,7 @@ Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | defa
 Fkey{{ lkidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'line' %}
 Fkey{{ lkidx }} Type               :2
-Fkey{{ lkidx }} Value              :SIP{{ lkidx }}
+Fkey{{ lkidx }} Value              :SIP1
 Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Line %s', language) | format(lkidx)) | slice(0,10) }}
 Fkey{{ lkidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'multicast_paging' %}


### PR DESCRIPTION
Always use SIP1 as line identifier to handle multiple calls on that line.