### PR TITLE
Immutable Fanvil template output

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -798,7 +798,7 @@ Common Cfg File Key:
 Download Server IP :{{ hostname }}
 Download Protocol  :{{ fanvil.scheme_map(provisioning_url_scheme) }}
 Download Mode      :{{ (provisioning_complete and provisioning_freq == 'never') ? '1' : '2' }}
-Download Interval  :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone) : '1' }}
+Download Interval  :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone, short_mac) : '1' }}
 DHCP Option        :0
 Save DHCP Opion    :0
 DHCP Option 120    :0

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -1008,7 +1008,7 @@ Flash Server IP    :{{ hostname }}
 Flash File Name    :{{ 'http' in provisioning_url_scheme ? (provisioning_url_path | trim('/', 'left') ~ tok2 ~ '/$mac.cfg') : '$mac.cfg' }}
 Flash Protocol     :{{ fanvil.scheme_map(provisioning_url_scheme) }}
 Flash Mode         :{{ (provisioning_complete and provisioning_freq == 'never') ? '1' : '2' }}
-Flash Interval     :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone) : '1' }}
+Flash Interval     :{{ provisioning_complete ? fanvil.upgrade_wait_hours(timezone, short_mac) : '1' }}
 update PB Interval :720
 AP Pswd Encryption :0
 Auto Image Url     :{{ firmware_file ? "#{provisioning_url_scheme}://#{hostname}/#{provisioning_url_path}#{tok2}/firmware/#{firmware_file}" : "" }}

--- a/data/templates/fanvil.macros
+++ b/data/templates/fanvil.macros
@@ -102,8 +102,18 @@
 #
 # Calculate the hours to wait before the next upgrade round
 #
-{% macro upgrade_wait_hours(timezone) %}
-    {{- ((('tomorrow 01:00' | date('U', timezone)) - ('now' | date('U', timezone)))/3600 + random(0,4)) | round -}}
+0123
+4567
+89ab
+cdef
+{% macro upgrade_wait_hours(timezone, short_mac) %}
+{% set offset = short_mac[-1:] | replace({
+  '0':'0', '1':'0', '2':'0', '3':'0',
+  '4':'1', '5':'2', '6':'3', '7':'4',
+  '8':'1', '9':'2', 'a':'3', 'b':'4',
+  'c':'1', 'd':'2', 'e':'3', 'f':'4'
+}) %}
+    {{- ((('tomorrow 01:00' | date('U', timezone)) - ('now' | date('U', timezone)))/3600 + offset) | round -}}
 {% endmacro upgrade_wait_hours %}
 
 #


### PR DESCRIPTION
The random() function causes multiple reboots: assign a fixed 
provisioning time offset, based on the device MAC address.