### PR TITLE
Sangoma phones uses lower case mac address

### DIFF
--- a/data/patterns.d/sangoma.ini
+++ b/data/patterns.d/sangoma.ini
@@ -1,5 +1,5 @@
 [sangoma-cfg005058]
-pattern = "cfg005058([A-F0-9]{2})([A-F0-9]{2})([A-F0-9]{2})\.xml"
+pattern = "cfg005058([a-f0-9]{2})([a-f0-9]{2})([a-f0-9]{2})\.xml"
 scopeid = "00-50-58-$1-$2-$3"
 template = "tmpl_phone"
 content_type = "text/xml; charset=utf-8"


### PR DESCRIPTION
Sangoma phones request don't match pattern because they request lower case mac address