### PR TITLE
Write upgrade script actions in log

### DIFF
--- a/scripts/upgrade.d/001.php
+++ b/scripts/upgrade.d/001.php
@@ -27,6 +27,7 @@ $names = array(
 
 # Rename scope files
 foreach ($names as $oldname => $newname) {
+    $container['logger']->info("Renaming $oldname => $newname");
     if (file_exists($container['config']['rw_dir'] . 'scopes/' . $oldname . '.ini')) {
         rename ($container['config']['rw_dir'] . 'scopes/' . $oldname . '.ini' , $container['config']['rw_dir'] . 'scopes/' . $newname . '.ini');
     }
@@ -36,6 +37,7 @@ foreach ($names as $oldname => $newname) {
 foreach ($container['storage']->listScopes($typeFilter = 'phone') as $id) {
     $scope = new \Tancredi\Entity\Scope($id, $container['storage'], $container['logger']);
     if (array_key_exists($scope->metadata['inheritFrom'], $names)) {
+        $container['logger']->info("Set inheritFrom to $id");
         $scope->metadata['inheritFrom'] = $names[$scope->metadata['inheritFrom']];
         $scope->setVariables();
     }
@@ -59,10 +61,11 @@ $displaynames = array(
     "yealink-T58" => "Yealink T58V/A"
 );
 
-# Rename scope files
+# Fix display name
 foreach ($displaynames as $id => $new_displayname) {
     $scope = new \Tancredi\Entity\Scope($id, $container['storage'], $container['logger']);
     if (empty($scope->metadata['version']) && $scope->metadata['displayName'] != $new_displayname) {
+        $container['logger']->info("Set displayName to $id");
         $scope->metadata['displayName'] = $new_displayname;
         $scope->metadata['version'] = 1;
         $scope->setVariables();
@@ -73,4 +76,4 @@ foreach ($displaynames as $id => $new_displayname) {
 $scope = new \Tancredi\Entity\Scope('defaults', $container['storage'], $container['logger']);
 $scope->metadata['version'] = 1;
 $scope->setVariables();
-
+$container['logger']->info("Set version 1 to defaults");

--- a/scripts/upgrade.d/002.php
+++ b/scripts/upgrade.d/002.php
@@ -14,3 +14,4 @@ $scope->setVariables([
     'vlan_id_phone' => '',
     'vlan_id_pcport' => '',
 ]);
+$container['logger']->info("Added vlan_id_phone and vlan_id_pcport to defaults");

--- a/scripts/upgrade.php
+++ b/scripts/upgrade.php
@@ -16,6 +16,6 @@ $container['storage'] = function($c) {
 # Launch update scripts
 $filesArray=glob(__DIR__ . "/upgrade.d/*.php");
 foreach ($filesArray as $file) {
-    $container['logger']->info("Launching upgrade script $file");
+    $container['logger']->debug("Launching upgrade script $file");
     include $file;
 }


### PR DESCRIPTION
For debugging and troubleshooting purposes, it's useful to write in tancredi.log what actually a single upgrade script do.

We know every script is invoked and every script immediately exits if has nothing to do. What is really important to know is what does an upgrade action and when it is run.

https://github.com/nethesis/dev/issues/5795 