### PR TITLE
Set VLAN VID to 0 or "" to disable

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -422,7 +422,7 @@ Account2 Password  :{{ userpw | default('1234') }}
 Account2 Level     :5
 
 <QOS CONFIG MODULE>
-Enable VLAN        :{{ vlan_id_phone != '' ? '1' : '0' }}
+Enable VLAN        :{{ vlan_id_phone > 0 ? '1' : '0' }}
 Enable diffServ    :0
 LLDP Transmit      :1
 LLDP Refresh Time  :60
@@ -431,13 +431,13 @@ CDP Enabled        :0
 CDP Refresh Time   :60
 Singalling DSCP    :46
 Voice DSCP         :46
-VLAN ID            :{{ (vlan_id_phone != '' and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}
+VLAN ID            :{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}
 Signalling Priority:0
 Voice Priority     :0
 LAN Port Priority  :0
 VLAN Recv Check    :1
-Enable PVID        :{{ vlan_id_pcport != '' ? '2' : '0' }}
-PVID Value         :{{ (vlan_id_pcport != '' and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
+Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '0' }}
+PVID Value         :{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
 DHCP Option Vlan   :0
 
 <DEBUG CONFIG MODULE>

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -1030,10 +1030,10 @@ Upgrade Server 2   :
 Auto Upgrade Interval:24
 
 <QOS CONFIG MODULE>
-Enable VLAN        :{{ vlan_id_phone != '' ? '1' : '0' }}
-VLAN ID            :{{ (vlan_id_phone != '' and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}
-Enable PVID        :{{ vlan_id_pcport != '' ? '2' : '0' }}
-PVID Value         :{{ (vlan_id_pcport != '' and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
+Enable VLAN        :{{ vlan_id_phone > 0 ? '1' : '0' }}
+VLAN ID            :{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}
+Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '0' }}
+PVID Value         :{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
 Signalling Priority:0
 Voice Priority     :0
 Video Priority     :0

--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -118,9 +118,9 @@
 {% else %}
     <param name="NET.VLAN.Tagging" value="0" />
 {% endif %}
-    <param name="NET.VLAN.LAN.Identifier" value ="{{ vlan_id_phone > 0 ? vlan_id_phone : '' }}" />
+    <param name="NET.VLAN.LAN.Identifier" value ="{{ vlan_id_phone > 0 and vlan_id_phone < 4095 ? vlan_id_phone : '0' }}" />
     <param name="NET.VLAN.LAN.Priority" value ="0" />
-    <param name="NET.VLAN.PC.Identifier" value ="{{ vlan_id_pcport > 0 ? vlan_id_pcport : '' }}" />
+    <param name="NET.VLAN.PC.Identifier" value ="{{ vlan_id_pcport > 0 and vlan_id_phone < 4095 ? vlan_id_pcport : '0' }}" />
     <param name="NET.VLAN.PC.Priority" value ="0" />
   </nvm>
   <custom>

--- a/data/templates/sangoma.tmpl
+++ b/data/templates/sangoma.tmpl
@@ -47,8 +47,8 @@
         <P5439 para="PackedInterval">120</P5439>
         <!--Network/Advance/Qos Set -->
         <P38 para="Layer3QoS">48</P38>
-        <P51 para="VLAN.WANPort.VID">{{ (vlan_id_phone != '' and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}</P51>
-        <P229 para="VLAN.PCPort.VID">{{ (vlan_id_pcport != '' and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}</P229>
+        <P51 para="VLAN.WANPort.VID">{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}</P51>
+        <P229 para="VLAN.PCPort.VID">{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}</P229>
         <!--Network/Advance/NTP Server-->
         <P30 para="UrlOrIpAddress">{{ ntp_server ?: 'pool.ntp.org' }}</P30>
         <P144 para="DHCPOverrideNTP">0</P144>

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -124,12 +124,12 @@ static.network.vlan.dhcp_enable = 0
 static.network.vlan.dhcp_option = 132
 static.network.vlan.vlan_change.enable = 1
 
-static.network.vlan.pc_port_vid = {{ vlan_id_pcport > 0 ? vlan_id_pcport : '1' }}
+static.network.vlan.pc_port_vid = {{ vlan_id_pcport > 0 and vlan_id_pcport < 4095 ? vlan_id_pcport : '1' }}
 static.network.vlan.pc_port_enable = {{ vlan_id_pcport > 0 ? '1' : '0' }}
 static.network.vlan.pc_port_priority = 0
 
 static.network.vlan.internet_port_priority = 0
-static.network.vlan.internet_port_vid = {{ vlan_id_phone > 0 ? vlan_id_phone : '1' }}
+static.network.vlan.internet_port_vid = {{ vlan_id_phone > 0 and vlan_id_phone < 4095 ? vlan_id_phone : '1' }}
 static.network.vlan.internet_port_enable = {{ vlan_id_phone > 0 ? '1' : '0' }}
 
 #######################################################################################


### PR DESCRIPTION
This PR fixes the `vlan_id_phone` and `vlan_id_pcport` value semantics to be the same for all models.

A zero (0) or empty string ("") value actually must lead to VLAN disabled. Originally the zero was somewhere interpreted as VID=0 that is a supported scenario in IEEE 802.1Q to use the tagging just for QoS purposes. 

As we do not address that scenario the 0 here is considered "disabled" and give us the benefit of enabling the VLAN in the model scope and easily disable it later in the single phone scope, as the empty string is already mapped by our UI to the "inherited from parent scope" value.

https://github.com/nethesis/dev/issues/5795