### PR TITLE
Bind Fanvil LDAP phonebook to SIP1

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -564,7 +564,7 @@ LDAP1 Authenticate :{{ ldap_password ? '3' : '0' }}
 LDAP1 Version      :3
 LDAP1 Calling Line :1
 LDAP1 Enable Search:0
-LDAP1 Bind Line    :0
+LDAP1 Bind Line    :1
 LDAP1 Base         :{{ ldap_base }}
 LDAP1 Use SSL      :
 {%- if ldap_tls == 'starttls' %}

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -569,8 +569,8 @@ LDAP1 Use SSL            :
     {{- '0' }}
 {% endif %}
 LDAP1 Version            :3
-LDAP1 Calling Line       :0
-LDAP1 Bind Line          :0
+LDAP1 Calling Line       :1
+LDAP1 Bind Line          :1
 LDAP1 In Call Search     :0
 LDAP1 Out Call Search    :0
 LDAP1 Authenticate       :{{ ( ldap_user and ldap_password and ldap_tls in ['ldaps', 'start_tls'] ) ? '3' : '0' }}


### PR DESCRIPTION
When an LDAP entry is selected for a new call always use SIP1.