### PR TITLE
New rules for opening downstream PR

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -2,8 +2,9 @@ name: PR for nethserver-tancredi RPM
 on:
   push:
     branches:
-      - master
-      - github-workflow-rpm
+      - nethvoice
+    tags:
+      - v1*
 
 jobs:
   open-pr:


### PR DESCRIPTION
Downstream PR is opened when we add a new tagged release or we push the special branch `nethvoice`