### PR TITLE
Fix default for VLAN pc port Fanvil

### DIFF
--- a/data/templates/fanvil-X3.tmpl
+++ b/data/templates/fanvil-X3.tmpl
@@ -428,7 +428,7 @@ Signalling Priority:0
 Voice Priority     :0
 LAN Port Priority  :0
 VLAN Recv Check    :1
-Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '0' }}
+Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '1' }}
 PVID Value         :{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
 DHCP Option Vlan   :0
 

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -1030,7 +1030,7 @@ Auto Upgrade Interval:24
 <QOS CONFIG MODULE>
 Enable VLAN        :{{ vlan_id_phone > 0 ? '1' : '0' }}
 VLAN ID            :{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? vlan_id_phone : '0' }}
-Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '0' }}
+Enable PVID        :{{ vlan_id_pcport > 0 ? '2' : '1' }}
 PVID Value         :{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '0' }}
 Signalling Priority:0
 Voice Priority     :0


### PR DESCRIPTION
Change default pc port Enable/Disable VLAN (Enable PVID) from 0 (follow WAN) to 1 (Disable) for Fanvil phones.