### PR TITLE
Allow to call GET /phones/{mac} with inherit=1

### DIFF
--- a/docs/paths/phonesMacGet.md
+++ b/docs/paths/phonesMacGet.md
@@ -35,9 +35,8 @@ Success response:
 }
 ```
 
-It is possible to query `model_url` with parameter `inherit=1` to obtain the
-default values for the items in `variables`. See also [GET
-/models/{name}]({{ "/paths/modelsNameGet" | relative_url }}).
+It is possible to add parameter `inherit=1` to obtain the values inherited from model and defaults for the items in `variables`.
+See also [GET/models/{name}]({{ "/paths/modelsNameGet" | relative_url }}).
 
 Failed response:
 

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -85,6 +85,7 @@ $app->get('/phones', function(Request $request, Response $response) use ($app) {
 **********************************/
 $app->get('/phones/{mac}', function(Request $request, Response $response, array $args) use ($app) {
     $mac = $args['mac'];
+    $query = $request->getQueryParams();
     // get all scopes of type "phone"
     if (!$this->storage->scopeExists($mac)) {
         $results = array(
@@ -96,7 +97,12 @@ $app->get('/phones/{mac}', function(Request $request, Response $response, array 
         $response = $response->withHeader('Content-Language', 'en');
         return $response;
     }
-    $response = $response->withJson(\Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger),200,JSON_FLAGS);
+    if (array_key_exists('inherit',$query) and $query['inherit'] == 1) {
+        $results = \Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger, TRUE);
+    } else {
+        $results = \Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger, FALSE);
+    }
+    $response = $response->withJson($results,200,JSON_FLAGS);
     return $response;
 });
 

--- a/public/api-v1.php
+++ b/public/api-v1.php
@@ -97,11 +97,8 @@ $app->get('/phones/{mac}', function(Request $request, Response $response, array 
         $response = $response->withHeader('Content-Language', 'en');
         return $response;
     }
-    if (array_key_exists('inherit',$query) and $query['inherit'] == 1) {
-        $results = \Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger, TRUE);
-    } else {
-        $results = \Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger, FALSE);
-    }
+    $inherit = isset($query['inherit']) && $query['inherit'] == 1;
+    $results = \Tancredi\Entity\Scope::getPhoneScope($mac, $this->storage, $this->logger, $inherit);
     $response = $response->withJson($results,200,JSON_FLAGS);
     return $response;
 });

--- a/test/bats/20_phones.bats
+++ b/test/bats/20_phones.bats
@@ -53,6 +53,12 @@ EOF
     assert_http_body "Адриан Нестор"
 }
 
+@test "GET /tancredi/api/v1/phones/01-23-45-67-89-AB?inherit=1 (success)" {
+    run GET /tancredi/api/v1/phones/01-23-45-67-89-AB?inherit=1
+    assert_http_code "200"
+    assert_http_body '"var1":"value1-changed"'
+}
+
 @test "POST /tancredi/api/v1/phones (01-23-45-67-89-AB, failed/conflict)" {
     run POST /tancredi/api/v1/phones <<EOF
 {


### PR DESCRIPTION
The `/phones/{mac}` API documentation states that

> It is possible to query `model_url` with parameter `inherit=1` to obtain the default values for the items in variables. See also `GET /models/{name}`.

Add the same behavior to `/phones/{mac}` itself.

https://github.com/nethesis/dev/issues/5845