### PR TITLE
Transfer two calls by placing the handset onhook for Snom

### DIFF
--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -14,6 +14,7 @@
         <vlan_pc_priority perm="">{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? '0' : '' }}</vlan_pc_priority>
 
         <transfer_on_hangup perm="">on</transfer_on_hangup>
+        <transfer_on_hangup_non_pots perm="">on</transfer_on_hangup_non_pots>
 
         <ntp_server perm="">{{ ntp_server ?: 'pool.ntp.org' }}</ntp_server>
         <date_us_format perm="">{{ snom.date_format(date_format) }}</date_us_format>


### PR DESCRIPTION
Add TRANSFER_ON_HANGUP_NON_POTS ON to transfer two calls by placing the handset onhook (independent of call direction (incoming / outgoing)

https://service.snom.com/display/wiki/transfer_on_hangup_non_pots