### PR TITLE
Extend Yealink TLS 1.2 fix #98 to T21P_E2

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2310,7 +2310,7 @@ static.security.user_password = user:{{ userpw | default('1234') }}
 static.security.user_name.var = var
 static.security.user_password = var:{{ userpw | default('1234') }}
 
-{% if provisioning_user_agent matches '/SIP-(T23G 4[0-4]|T23P 4[0-4]|T27G 6[0-9]|T27P 6[0-9]|T58 5[0-9])\.8[4-9]/' %}
+{% if provisioning_user_agent matches '/SIP-(T21P_E2 5[0-4]|T23G 4[0-4]|T23P 4[0-4]|T27G 6[0-9]|T27P 6[0-9]|T58 5[0-9])\.8[4-9]/' %}
 # Fix TLS error 218910881 (ASN1_item_verify-unknown message digest algorithm)
 sip.tls_cipher_list=!ECDH:AES:!ADH:!LOW:!NULL
 security.tls_cipher_list =!ECDH:AES:!ADH:!LOW:!NULL


### PR DESCRIPTION
Extend Yealink TLS 1.2 fix #98 to T21P_E2

See #98 -- Fix TLS error 218910881 (ASN1_item_verify-unknown message digest algorithm)