### PR TITLE
Skip Yealink expansion module settings

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -1313,9 +1313,9 @@ phone_setting.backgrounds = {{ background_file }}
 phone_setting.backgrounds_with_dsskey_unfold = Auto
 
 ##expansion_module.backgrounds(Only support T5XW/T54S/T52S)
-expansion_module.backgrounds = {{ exp_backgrounds }}
-expansion_module.page_tip.blf_call_in.enable = 1
-expansion_module.page_tip.blf_call_in.led = $LEDr300o300$
+expansion_module.backgrounds = %NULL%
+expansion_module.page_tip.blf_call_in.enable = %NULL%
+expansion_module.page_tip.blf_call_in.led = %NULL%
 
 #######################################################################################
 ##                               BSFT Setting                                        ##


### PR DESCRIPTION
- The `exp_backgrounds` variable is currently not defined. Rely on the factory default value or the web UI settings.
- Do not lock `blf_call_in` LED settings to factory defaults (see image below), so we can override by other means.



![image](https://user-images.githubusercontent.com/2920838/89509506-b13d2d00-d7cf-11ea-965c-7a79ec622fcf.png)


See also https://partner.nethesis.it/t/nuovo-provisioning-caricare-sfondo-telefoni-yealink/3981