### PR TITLE
Always set programmable keys to some value

### DIFF
--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -91,9 +91,7 @@
     {# soft keys #}
     {% if cap_softkey_count > 0 %}
       {% for number in 1..(cap_softkey_count) %}
-        {% if _context['softkey_type_' ~ number] is defined %}
           {{ gigaset.softkey_type_map(_context['softkey_type_' ~ number], (number-1)) }}
-        {% endif %}
       {% endfor %}
     {% endif %}
     {# end soft keys #}

--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -100,11 +100,7 @@
     {# line keys #}
     {% if cap_linekey_count > 0 %}
       {% for number in 1..(cap_linekey_count) %}
-        {% if _context['linekey_type_' ~ number] is defined %}
-          {{ gigaset.linekey_type_map(_context['linekey_type_' ~ number], (number-1), _context['linekey_value_' ~ number], dndtoggle, pickup_group, queuetoggle) }}
-        {% else %}
-            <param name="PhoneUI.Keys.FunctionKeys.{{number-1}}.Type" value="-1" />
-        {% endif %}
+        {{ gigaset.linekey_type_map(_context['linekey_type_' ~ number], (number-1), _context['linekey_value_' ~ number], dndtoggle, pickup_group, queuetoggle) }}
         <param name="PhoneUI.Keys.FunctionKeys.{{number-1}}.DisplayName" value="{{_context['linekey_label_' ~ number]}}" />
       {% endfor %}
     {% endif %}

--- a/data/templates/gigaset.macros
+++ b/data/templates/gigaset.macros
@@ -69,6 +69,8 @@
 {% elseif linekey_type == "voice_mail" %}
     <param name="PhoneUI.Keys.FunctionKeys.{{ number }}.Type" value="10" />
     <param name="PhoneUI.Keys.FunctionKeys.{{ number }}.EnableCode" value="{{ account_voicemail_1 }}" />
+{% else %}
+    <param name="PhoneUI.Keys.FunctionKeys.{{ number }}.Type" value="-1" />
 {% endif %}
 {% endmacro linekey_type_map %}
 

--- a/data/templates/gigaset.macros
+++ b/data/templates/gigaset.macros
@@ -86,6 +86,8 @@
     <param name="PhoneUI.Keys.SoftKeys.{{number}}.DisableCode" value="*8"/>
     <param name="PhoneUI.Keys.SoftKeys.{{number}}.EnableName" value="Pickup"/>
     <param name="PhoneUI.Keys.SoftKeys.{{number}}.DisableName" value="Pickup"/>
+{% else %}
+    <param name="PhoneUI.Keys.SoftKeys.{{number}}.Type" value="-1"/>
 {% endif %}
 {% endmacro softkey_type_map %}
 

--- a/data/templates/sangoma.tmpl
+++ b/data/templates/sangoma.tmpl
@@ -98,10 +98,8 @@
         <!--ExpKeys-->
         {%- for m in cap_expmodule_count ? range(0, cap_expmodule_count - 1) : [] -%}
         {%- for k in 0..(cap_expkey_count - 1) -%}
-        {%- set idx = 1 + k + (m * cap_expkey_count) -%}
-        {%- if _context["expkey_type_#{idx}"] is defined %}
+        {%- set idx = 1 + k + (m * cap_expkey_count) %}
         {{ sangoma.pcode_expkey(m, k, _context["expkey_type_#{idx}"], _context["expkey_value_#{idx}"], _context["expkey_label_#{idx}"]) -}}
-        {%- endif -%}
         {%- endfor -%}
         {% endfor %}
 

--- a/data/templates/snom.macros
+++ b/data/templates/snom.macros
@@ -41,7 +41,7 @@
 {% elseif linekey_type == "group_pickup" %}
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">speed {{ pickup_group }}</fkey>
 {% else %}
-    <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">none {{ linekey_value }}</fkey>
+    <fkey idx="{{ (number-1) }}" context="active" label="" lp="on" perm="">line</fkey>
 {% endif %}
 {% endmacro linekey_type_map %}
 

--- a/data/templates/snom.macros
+++ b/data/templates/snom.macros
@@ -14,8 +14,6 @@
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">line {{ linekey_value }}</fkey>
 {% elseif linekey_type == "multicast_paging" %}
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">multicast {{ linekey_value }}</fkey>
-{% elseif linekey_type == "" %}
-    <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">none {{ linekey_value }}</fkey>
 {% elseif linekey_type == "record" %}
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">record {{ linekey_value }}</fkey>
 {% elseif linekey_type == "speed_dial" %}
@@ -42,6 +40,8 @@
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">keyevent F_DND</fkey>
 {% elseif linekey_type == "group_pickup" %}
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">speed {{ pickup_group }}</fkey>
+{% else %}
+    <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">none {{ linekey_value }}</fkey>
 {% endif %}
 {% endmacro linekey_type_map %}
 

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -143,10 +143,7 @@
         <prov_polling_time_rand_end perm="">04:00</prov_polling_time_rand_end>
 
         {% for number in 1..cap_softkey_count %}
-            {%- if _context['softkey_type_' ~ number] is defined -%}
-                {% if _context['softkey_type_' ~ number] == 'disabled' -%}
-                    <gui_fkey{{ number }} perm="">keyevent none</gui_fkey{{ number }}>
-                {% elseif _context['softkey_type_' ~ number] == 'forward' -%}
+                {% if _context['softkey_type_' ~ number] == 'forward' -%}
                     <gui_fkey{{ number }} perm="">keyevent F_REDIRECT</gui_fkey{{ number }}>
                 {% elseif _context['softkey_type_' ~ number] == 'dnd' -%}
                     <gui_fkey{{ number }} perm="">keyevent F_DND</gui_fkey{{ number }}>
@@ -167,7 +164,6 @@
                 {% else -%}
                     <gui_fkey{{ number }} perm="">keyevent none</gui_fkey{{ number }}>
                 {% endif -%}
-            {%- endif -%}
         {% endfor %}
     </phone-settings>
     <functionKeys>

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -173,12 +173,6 @@
                     {{snom.linekey_type_map(_context['linekey_type_' ~ number], _context['linekey_value_' ~ number], _context['linekey_label_' ~ number], dndtoggle, pickup_group, number, queuetoggle)}}
             {% endfor %}
         {% endif %}
-        {# expansion keys #}
-        {% for number in lineKeys..125 %}
-            {% if _context['expkey_type_' ~ number] is defined %}
-                <fkey idx="{{ number }}" context="active" label="{{ _context['expkey_label_' ~ number] }}" lp="on" default_text="$name" perm="">{{ _context['expkey_type_' ~ number] }} {{ _context['expkey_value_' ~ number] }}</fkey>
-            {% endif %}
-        {% endfor %}
     </functionKeys>
 {% endautoescape %}
 </settings>

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -170,9 +170,7 @@
         {# line keys #}
         {% if cap_linekey_count > 0 %}
             {% for number in 1..(cap_linekey_count) %}
-                {% if _context['linekey_type_' ~ number] is defined %}
                     {{snom.linekey_type_map(_context['linekey_type_' ~ number], _context['linekey_value_' ~ number], _context['linekey_label_' ~ number], dndtoggle, pickup_group, number, queuetoggle)}}
-                {% endif %}
             {% endfor %}
         {% endif %}
         {# expansion keys #}

--- a/data/templates/yealink.macros
+++ b/data/templates/yealink.macros
@@ -1007,7 +1007,7 @@
         "zero_touch": "41"
         }
     -%}
-{{- map[linekey_type] ?? '0' -}}
+{{- map[linekey_type] ?: '0' -}}
 {% endmacro linekey_type %}
 
 #
@@ -1050,7 +1050,7 @@
         "dect_intercom": "310"
         }
     -%}
-{{- map[softkey_type] ?? '0' -}}
+{{- map[softkey_type] ?: '0' -}}
 {% endmacro softkey_type %}
 
 #

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2260,7 +2260,9 @@ linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] }}
 {% for module in 1..cap_expmodule_count %}
 {% for number in 1..cap_expkey_count %}
 {# Skip expkey 21 #}
-{% if number != 21 %}
+{% if cap_expkey_count == 38 and number == 21 %}
+# Skip button 21 of EXP20 -- page switch button
+{% else %}
 # Expansion module {{ module }}, Key {{ number }}
 expansion_module.{{ module }}.key.{{ number }}.type = {{ yealink.linekey_type(_context['expkey_type_' ~ expkey]) }}
 expansion_module.{{ module }}.key.{{ number }}.value = {{ _context['expkey_value_' ~ expkey] }}

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2219,7 +2219,6 @@ bw.virtual_user.1.xsi.user =
 ##Programablekey X ranges(T48G/T48S/T46G/T46S: X=1-10, 12-14;T42G/T42S/T41P/T41S/T40P/T40G: X=1-10, 13;T29G/T27P/T27G: X=1-14;T23P/T23G/T21(P) E2: 1-10, 14;T19(P) E2: X=1-9, 13, 14;)##
 
 {% for softkey in 1..cap_softkey_count %}
-{% if _context['softkey_type_' ~ softkey] is defined and _context['softkey_type_' ~ softkey] != "" %}
 # Softkey {{ number }}
 programablekey.{{ softkey }}.type = {{ yealink.softkey_type(_context['softkey_type_' ~ softkey]) }}
 programablekey.{{ softkey }}.line = 1
@@ -2236,7 +2235,6 @@ programablekey.{{ softkey }}.pickup_value =
  %NULL%
 {% endif %}
 
-{% endif %}
 {% endfor %}
 ##V83 Add
 programablekey.type_range.custom =
@@ -2254,7 +2252,6 @@ programablekey.type_range.custom =
 ## Not support T19P_E2
 
 {% for number in 1..cap_linekey_count %}
-{% if _context['linekey_type_' ~ number] is defined and _context['linekey_type_' ~ number] != "" %}
 # Linekey {{ number }}
 linekey.{{ number }}.type = {{ yealink.linekey_type(_context['linekey_type_' ~ number]) }}
 linekey.{{ number }}.line = {{ _context['linekey_line_' ~ number] | default('1') }}
@@ -2267,7 +2264,6 @@ linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] | default('%
 linekey.{{ number }}.extension = %NULL%
 linekey.{{ number }}.xml_phonebook = %NULL%
 
-{% endif %}
 {% endfor %}
 #######################################################################################
 ##                                Expansion Key                                      ##

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2254,20 +2254,13 @@ linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] }}
 #######################################################################################
 ##                                Expansion Key                                      ##
 #######################################################################################
-##expansion_module.X.key.Y.type
-##expansion_module.X.key.Y.line
-##expansion_module.X.key.Y.value
-##expansion_module.X.key.Y.extension
-##expansion_module.X.key.Y.label
-##expansion_module.X.key.Y.xml_phonebook
-## Expansion Key X ranges(SIP-T5XW/T54S/T52S: X ranges from 1 to 3, Y ranges from 1 to 60; SIP-T48G/T48S/T46G/T46S:X ranges from 1 to 6, Y ranges from 1 to 40; SIP-T29G/T27P/T27G:X ranges from 1 to 6, Y ranges from 1 to 20, 22 to 40 (Ext key 21 cannot be configured).)##
-## Only SIP-T5XW/T54S/T52S/T48G/T48S/T46G/T46S/T29G/T27P/T27G Models support the parameter.
 
+{% if cap_expkey_count > 0 and cap_expmodule_count > 0 %}
 {% set expkey = 1 %}
 {% for module in 1..cap_expmodule_count %}
 {% for number in 1..cap_expkey_count %}
 {# Skip expkey 21 #}
-{% if cap_expmodule_count != 38 and number != 21 %}
+{% if number != 21 %}
 # Expansion module {{ module }}, Key {{ number }}
 expansion_module.{{ module }}.key.{{ number }}.type = {{ yealink.linekey_type(_context['expkey_type_' ~ expkey]) }}
 expansion_module.{{ module }}.key.{{ number }}.value = {{ _context['expkey_value_' ~ expkey] }}
@@ -2277,6 +2270,7 @@ expansion_module.{{ module }}.key.{{ number }}.label = {{ _context['expkey_label
 {% endif %}
 {% endfor %}
 {% endfor %}
+{% endif %}
 #######################################################################################
 ##                               Security                                            ##
 #######################################################################################

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2221,11 +2221,8 @@ bw.virtual_user.1.xsi.user =
 {% for softkey in 1..cap_softkey_count %}
 # Softkey {{ number }}
 programablekey.{{ softkey }}.type = {{ yealink.softkey_type(_context['softkey_type_' ~ softkey]) }}
-programablekey.{{ softkey }}.line = 1
-programablekey.{{ softkey }}.value = {{ _context['softkey_value_' ~ softkey] | default('%NULL%') }}
-programablekey.{{ softkey }}.label = {{ _context['softkey_label_' ~ softkey] | default('%NULL%') }}
-programablekey.{{ softkey }}.extension = %NULL%
-programablekey.{{ softkey }}.xml_phonebook = %NULL%
+programablekey.{{ softkey }}.value = {{ _context['softkey_value_' ~ softkey] }}
+programablekey.{{ softkey }}.label = {{ _context['softkey_label_' ~ softkey] }}
 programablekey.{{ softkey }}.pickup_value = 
 {%- if _context['softkey_type_' ~ softkey] == 'pick_up' %}
     {{ pickup_direct }}
@@ -2242,27 +2239,16 @@ programablekey.type_range.custom =
 #######################################################################################
 ##                                  Linekey                                          ##
 #######################################################################################
-##linekey.X.type
-##linekey.X.line
-##linekey.X.value
-##linekey.X.label
-##linekey.X.extension
-##linekey.X.xml_phonebook
-##LineKeyX ranges(T57W/T48G/S: X ranges from 1 to 29. T53W/T54W/T54S/T46G/T46S/T29G: X ranges from 1 to 27. T42G/T42S/T41P/T41S: X ranges from 1 to 15. T40P/T40G/T23P/T23G: X ranges from 1 to 3. T52S/T27P/T27G: X ranges from 1 to 21. T21(P) E2: X ranges from 1 to 2.)##
-## Not support T19P_E2
 
 {% for number in 1..cap_linekey_count %}
 # Linekey {{ number }}
 linekey.{{ number }}.type = {{ yealink.linekey_type(_context['linekey_type_' ~ number]) }}
-linekey.{{ number }}.line = {{ _context['linekey_line_' ~ number] | default('1') }}
 {% if _context['linekey_type_' ~ number] == "queuetoggle" %}
-    linekey.{{ number }}.value = {{ queuetoggle | default('%NULL%') }}
+    linekey.{{ number }}.value = {{ queuetoggle }}
 {% else %}
-    linekey.{{ number }}.value = {{ _context['linekey_value_' ~ number] | default('%NULL%') }}
+    linekey.{{ number }}.value = {{ _context['linekey_value_' ~ number] }}
 {% endif %}
-linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] | default('%NULL%') }}
-linekey.{{ number }}.extension = %NULL%
-linekey.{{ number }}.xml_phonebook = %NULL%
+linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] }}
 
 {% endfor %}
 #######################################################################################
@@ -2282,17 +2268,12 @@ linekey.{{ number }}.xml_phonebook = %NULL%
 {% for number in 1..cap_expkey_count %}
 {# Skip expkey 21 #}
 {% if cap_expmodule_count != 38 and number != 21 %}
-{% if _context['expkey_type_' ~ expkey] is defined and _context['expkey_type_' ~ expkey] != "" %}
 # Expansion module {{ module }}, Key {{ number }}
 expansion_module.{{ module }}.key.{{ number }}.type = {{ yealink.linekey_type(_context['expkey_type_' ~ expkey]) }}
-expansion_module.{{ module }}.key.{{ number }}.line = {{ _context['expkey_line_' ~ expkey] | default('1') }}
-expansion_module.{{ module }}.key.{{ number }}.value = {{ _context['expkey_value_' ~ expkey] | default('%NULL%') }}
-expansion_module.{{ module }}.key.{{ number }}.label = {{ _context['expkey_label_' ~ expkey] | default('%NULL%') }}
-expansion_module.{{ module }}.key.{{ number }}.extension = %NULL%
-expansion_module.{{ module }}.key.{{ number }}.xml_phonebook = %NULL%
+expansion_module.{{ module }}.key.{{ number }}.value = {{ _context['expkey_value_' ~ expkey] }}
+expansion_module.{{ module }}.key.{{ number }}.label = {{ _context['expkey_label_' ~ expkey] }}
 
 {% set expkey =  expkey + 1 %}
-{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -2243,9 +2243,9 @@ programablekey.type_range.custom =
 {% for number in 1..cap_linekey_count %}
 # Linekey {{ number }}
 linekey.{{ number }}.type = {{ yealink.linekey_type(_context['linekey_type_' ~ number]) }}
-{% if _context['linekey_type_' ~ number] == "queuetoggle" %}
+{% if _context['linekey_type_' ~ number] == "queuetoggle" -%}
     linekey.{{ number }}.value = {{ queuetoggle }}
-{% else %}
+{% else -%}
     linekey.{{ number }}.value = {{ _context['linekey_value_' ~ number] }}
 {% endif %}
 linekey.{{ number }}.label = {{ _context['linekey_label_' ~ number] }}


### PR DESCRIPTION
The Fanvil template already implements the behavior proposed by this PR: *if a programmable key is not defined at all, provision it in the "disabled" state*.

This is necessary, otherwise if a key is assigned a particular type and disabled (or the scope is removed) at a later step the new "disabled" state is never provisioned.

Please check the PR patch one commit at a time.

:warning: verify the correct output spacing before merging

**See also**

https://partner.nethesis.it/t/nuovo-provisioning-migliorie-tasti-blf/3983