### PR TITLE
Ignore DHCP options 66 and 114 in Gigaset

### DIFF
--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -28,6 +28,7 @@
     <param name="FirmwareManagment.AutomaticCheckForUpdates" value="{{ firmware_file ? '1' : '0' }}" />
     <param name="System.Provision.Period" value="{{ provisioning_complete ? '0' : '600' }}" />
     <param name="System.Provision.ProvisioningServer" value="{{ provisioning_url2 | replace({'%25': '%'}) }}" />
+    <param name="NET.IP.IPv4.DHCP.Options.Disabled" value="66,114" />
 
     <param name="SIP.Port" value="{{ account_encryption_1 ? sip_tls_port : sip_udp_port }}" />
     <param name="SIP.RTP.Port" value="5004"  />


### PR DESCRIPTION
According to https://teamwork.gigaset.com/gigawiki/display/GPPPO/FAQ+Maxwell+-+Auto+provisioning+Flow the DHCP option 66 and 114 always have higher priority over the provisioning URL.

This PR wants to implement the behavior of other vendors: once the provisioning URL is set, ignore any DHCP option that can override it.