### PR TITLE
Yealink: add reason call fail

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -604,6 +604,7 @@ sip.reliable_protocol.timerae.enable = 0
 sip.requesturi.e164.addglobalprefix = 0
 sip.trust_ctrl = 0
 sip.mac_in_ua = 0
+sip.call_fail_use_reason.enable = 0
 
 sip.timer_t1 = 0.5
 sip.timer_t2 = 4


### PR DESCRIPTION
Yealink: add sip.call_fail_use_reason.enable for show right sip call fail reason on phone display
https://partner.nethesis.it/t/nethvoice-14-quality-team-nuovo-modulo-per-il-provisioning/3168/368