### PR TITLE
Impossible to transfer an incoming call with Gigaset Maxwell

### DIFF
--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -32,7 +32,7 @@
 
     <param name="SIP.Port" value="{{ account_encryption_1 ? sip_tls_port : sip_udp_port }}" />
     <param name="SIP.RTP.Port" value="5004"  />
-    <param name="SIP.Security.UseSIPS" value="{{ account_encryption_1 ? '2' : '0' }}" />
+    <param name="SIP.Security.UseSIPS" value="{{ account_encryption_1 ? '1' : '0' }}" />
     <param name="SIP.TransportProtocol" value="{{ account_encryption_1 ? '2' : '1' }}" />
     <param name="SIP.Security.SRTP" value="{{ account_encryption_1 ? '1' : '0' }}" />
     <param name="SIP.Security.AcceptNonSRTPCalls" value="{{ account_encryption_1 ? '0' : '1' }}" />


### PR DESCRIPTION
It's impossible to Transfer an incoming call with SIP.Security.UseSIPS value = 2.

Gigaset Maxwell with TLS configuration. Change SIP.Security.UseSIPS to 1 for Maxwell trasfer feature.

SIP.Security.UseSIPS value = 1 fix the issue.

SIP.Security.UseSIP:

0 => TLS is disabled

1 => TLS is enabled, SIP scheme enabled

2 => TLS is enabled, SIPS scheme enabled