### PR TITLE
Add vlan_port_tagging if pc vlan id is present

### DIFF
--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -10,6 +10,7 @@
         <lldp_enable perm="">off</lldp_enable>
         <vlan_id perm="">{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? vlan_id_phone : '' }}</vlan_id>
         <vlan_qos perm="">{{ (vlan_id_phone > 0 and vlan_id_phone < 4095) ? '0' : '' }}</vlan_qos>
+        <vlan_port_tagging perm="">{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? 'on' : 'off' }}</vlan_port_tagging>
         <vlan_pc_id perm="">{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? vlan_id_pcport : '' }}</vlan_pc_id>
         <vlan_pc_priority perm="">{{ (vlan_id_pcport > 0 and vlan_id_pcport < 4095) ? '0' : '' }}</vlan_pc_priority>
 


### PR DESCRIPTION
Snom deskphones have an internal ethernet switch capable of handling vlan (set tags and unset them). This setting defines whether the switch will handle the vlan tagging or not.

Handling means that packets from the internal ports to the network are tagged (vlan id is added) and tagged packets (vlan set) from the network are untagged (vlan id is removed) and assigned to the port they belong (selection by vlan id).

https://service.snom.com/display/wiki/vlan_port_tagging
