### PR TITLE
Add Fanvil X7C and sidekeys pages

### DIFF
--- a/data/scopes/fanvil-X210.ini
+++ b/data/scopes/fanvil-X210.ini
@@ -1,13 +1,14 @@
 [metadata]
 scopeType = "model"
 displayName = "Fanvil X210"
-version = 5
+version = 9
 
 [data]
 cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 fanvil_sidekey_count = 10
+fanvil_sidepages_count = 1
 fanvil_lkpages_count = 3
 cap_linekey_count = 106
 cap_linekey_type_blacklist =

--- a/data/scopes/fanvil-X3U.ini
+++ b/data/scopes/fanvil-X3U.ini
@@ -1,13 +1,15 @@
 [metadata]
 scopeType = "model"
 displayName = "Fanvil X3U"
-version = 5
+version = 9
 
 [data]
 cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 fanvil_sidekey_count = 3
+fanvil_sidepages_count = 1
+fanvil_lkpages_count = 0
 cap_linekey_count = 3
 cap_linekey_type_blacklist =
 cap_softkey_count = 4

--- a/data/scopes/fanvil-X4U.ini
+++ b/data/scopes/fanvil-X4U.ini
@@ -1,13 +1,14 @@
 [metadata]
 scopeType = "model"
 displayName = "Fanvil X4U"
-version = 5
+version = 9
 
 [data]
 cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 fanvil_sidekey_count = 3
+fanvil_sidepages_count = 1
 cap_linekey_count = 33
 cap_linekey_type_blacklist =
 cap_softkey_count = 4

--- a/data/scopes/fanvil-X5U.ini
+++ b/data/scopes/fanvil-X5U.ini
@@ -1,13 +1,14 @@
 [metadata]
 scopeType = "model"
 displayName = "Fanvil X5U"
-version = 4
+version = 9
 
 [data]
 cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
 fanvil_sidekey_count = 4
+fanvil_sidepages_count = 1
 cap_linekey_count = 34
 cap_linekey_type_blacklist =
 cap_softkey_count = 4

--- a/data/scopes/fanvil-X7C.ini
+++ b/data/scopes/fanvil-X7C.ini
@@ -1,15 +1,16 @@
 [metadata]
 scopeType = "model"
-displayName = "Fanvil X6U"
+displayName = "Fanvil X210"
 version = 9
 
 [data]
 cap_ldap_tls_blacklist =
 provisioning_url_filename = "$mac.cfg"
 tmpl_phone = "fanvil-X5.tmpl"
-fanvil_sidekey_count = 5
-fanvil_sidepages_count = 1
-cap_linekey_count = 65
+cap_linekey_count = 60
+fanvil_lkpages_count = 0
+fanvil_sidekey_count = 60
+fanvil_sidepages_count = 5
 cap_linekey_type_blacklist =
 cap_softkey_count = 4
 cap_softkey_type_blacklist =

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -1,6 +1,8 @@
 <<VOIP CONFIG FILE>>Version:2.0000000000                      
 {% import 'fanvil.macros' as fanvil %}
 {% import 'language.macros' as l10n %}
+{% set fanvil_lkpages_count = fanvil_lkpages_count | default(5) %}
+{% set fanvil_sidepages_count = fanvil_sidepages_count | default(0) %}
 
 <NET CONFIG MODULE>
 WAN TYPE           :0
@@ -686,10 +688,8 @@ MCAST10 Channel            :0
 <DSSKEY CONFIG MODULE>
 Select DsskeyAction:0
 Memory Key to BXfer:{{ dss_transfer }}
-{% set lkpages = fanvil_lkpages_count | default(5) %}
-{% set sidepages = fanvil_sidepages_count | default(0) %}
-FuncKey Page Num   :{{ lkpages }}
-SideKey Page Num   :{{ sidepages }}
+FuncKey Page Num   :{{ fanvil_lkpages_count }}
+SideKey Page Num   :{{ fanvil_sidepages_count }}
 DSS Home Page      :1
 DSS DIAL Switch Mode :0
 First Call Wait Time :16
@@ -710,140 +710,44 @@ DSS Extend4 MAC     :
 DSS Extend4 IP      :
 DSS Extend5 MAC     :
 DSS Extend5 IP      :
-{% set dss_transfer_map = {
-    'verify': 'c',
-    'blind': 'b',
-    'attended': 'a',
-} %}
-{% set linekey_count = cap_linekey_count - fanvil_sidekey_count %}
-{% set lkcount = (linekey_count // lkpages) %}
-{% set sidecount = (fanvil_sidekey_count // sidepages) %}
-{% for pages in range( 1, sidepages+lkpages) %}
-{% if pages <= sidepages %}
---Sidekey Config{{ pages }}--:
-{% else %}
---Dsskey Config{{ pages - sidepages }}--:
-{% endif %}
-{% for keyidx in range(1, pages <= sidepages ? sidecount : lkcount) %}
-{% if pages == 1 %}
-{% set index = keyidx %}
-{% elseif pages <= sidepages %}
-{% set index = keyidx + (sidecount * (pages-1)) %}
-{% else %}
-{% set index = keyidx + sidecount + (lkcount * (pages-sidepages-1)) %}
-{% endif %}
-{% if _context['linekey_type_' ~ index] == 'blf' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/b'
-                                    ~ (dss_transfer_map[dss_transfer] ?? 'a')
-                                    ~ pickup_direct ~ _context['linekey_value_' ~ index]
-                                    }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'conference' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/bf'
-                                    ~ pickup_direct ~ _context['linekey_value_' ~ index]
-                                    }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'direct_pickup' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_PICKUP
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10)  }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'dnd' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_DND
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('DND', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'dtmf' %}
-Fkey{{ keyidx }} Type               :4
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'forward' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/a' }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'group_pickup' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ pickup_group ~ '@1/f' }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'hold' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_HOLD
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Hold', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'ldap' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_LDAPCONTACTS:1
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Phonebook', language)) | slice(0,10)  }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'line' %}
-Fkey{{ keyidx }} Type               :2
-Fkey{{ keyidx }} Value              :SIP1
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Line %s', language) | format(keyidx)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'multicast_paging' %}
-Fkey{{ keyidx }} Type               :14
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '/PCMU' }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index]  | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'phone_lock' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_LOCK
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Lock phone', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'prefix' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_PREFIX:{{ _context['linekey_value_' ~ index] }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'recall' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_REDIAL
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Redial', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'record' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_RECORD
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Record', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'speed_dial' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/f' }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'queuetoggle' %}
-Fkey{{ keyidx }} Type               :1
-Fkey{{ keyidx }} Value              :{{ queuetoggle ~ '@1/f' }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'transfer' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_B_TRANSFER
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Transfer', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'url' %}
-Fkey{{ keyidx }} Type               :7
-Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] }}
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('URL', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% elseif _context['linekey_type_' ~ index] == 'voice_mail' %}
-Fkey{{ keyidx }} Type               :3
-Fkey{{ keyidx }} Value              :F_MWI
-Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Voice mail', language)) | slice(0,10) }}
-Fkey{{ keyidx }} ICON               :Green
-{% else %}
-Fkey{{ keyidx }} Type               :0
-Fkey{{ keyidx }} Value              :
-Fkey{{ keyidx }} Title              :
-Fkey{{ keyidx }} ICON               :Green
-{% endif %}
 
+{# Linear index for linekey_type_{index} #}
+{% set index = 0 %}
+{# Side key loop #}
+{% for pageidx in fanvil_sidepages_count == 0 ? [] : range(1, fanvil_sidepages_count) %}
+--Sidekey Config{{ pageidx }}--:
+{% for keyidx in range(1, fanvil_sidekey_count // fanvil_sidepages_count) %}
+{% set index = index + 1 %}
+{{ fanvil.linekey_type_map(
+    _context['linekey_type_' ~ index],
+    _context['linekey_value_' ~ index],
+    _context['linekey_label_' ~ index],
+    keyidx,
+    l10n,
+    pickup_direct,
+    pickup_group,
+    dss_transfer,
+    queuetoggle
+) }}
+{% endfor %}
+{% endfor %}
+{# Dss key loop #}
+{% for pageidx in fanvil_lkpages_count == 0 ? [] : range(1, fanvil_lkpages_count) %}
+--Dsskey Config{{ pageidx }}--:
+{% for keyidx in range(1, (cap_linekey_count - fanvil_sidekey_count) // fanvil_lkpages_count) %}
+{% set index = index + 1 %}
+{{ fanvil.linekey_type_map(
+    _context['linekey_type_' ~ index],
+    _context['linekey_value_' ~ index],
+    _context['linekey_label_' ~ index],
+    keyidx,
+    l10n,
+    language,
+    pickup_direct,
+    pickup_group,
+    dss_transfer,
+    queuetoggle
+) }}
 {% endfor %}
 {% endfor %}
 

--- a/data/templates/fanvil-X5.tmpl
+++ b/data/templates/fanvil-X5.tmpl
@@ -686,8 +686,10 @@ MCAST10 Channel            :0
 <DSSKEY CONFIG MODULE>
 Select DsskeyAction:0
 Memory Key to BXfer:{{ dss_transfer }}
-FuncKey Page Num   :5
-SideKey Page Num   :1
+{% set lkpages = fanvil_lkpages_count | default(5) %}
+{% set sidepages = fanvil_sidepages_count | default(0) %}
+FuncKey Page Num   :{{ lkpages }}
+SideKey Page Num   :{{ sidepages }}
 DSS Home Page      :1
 DSS DIAL Switch Mode :0
 First Call Wait Time :16
@@ -708,133 +710,138 @@ DSS Extend4 MAC     :
 DSS Extend4 IP      :
 DSS Extend5 MAC     :
 DSS Extend5 IP      :
-
 {% set dss_transfer_map = {
     'verify': 'c',
     'blind': 'b',
     'attended': 'a',
 } %}
-{% set lkpages = fanvil_lkpages_count | default(5) %}
-{% set fanvil_sidekey_count = fanvil_sidekey_count | default(0) %}
-{% set lkcount = (cap_linekey_count - fanvil_sidekey_count) // lkpages %}
-{% for lkpage in range((fanvil_sidekey_count > 0 ? 0 : 1), lkpages) %}
-{% if lkpage == 0 %}
---Sidekey Config1--:
+{% set linekey_count = cap_linekey_count - fanvil_sidekey_count %}
+{% set lkcount = (linekey_count // lkpages) %}
+{% set sidecount = (fanvil_sidekey_count // sidepages) %}
+{% for pages in range( 1, sidepages+lkpages) %}
+{% if pages <= sidepages %}
+--Sidekey Config{{ pages }}--:
 {% else %}
---Dsskey Config{{ lkpage }}--:
+--Dsskey Config{{ pages - sidepages }}--:
 {% endif %}
-{% for lkidx in range(1, lkpage == 0 ? fanvil_sidekey_count : lkcount) %}
-{% set index = lkidx + (lkpage == 0 ? 0 : (lkcount * (lkpage-1) + fanvil_sidekey_count)) %}
+{% for keyidx in range(1, pages <= sidepages ? sidecount : lkcount) %}
+{% if pages == 1 %}
+{% set index = keyidx %}
+{% elseif pages <= sidepages %}
+{% set index = keyidx + (sidecount * (pages-1)) %}
+{% else %}
+{% set index = keyidx + sidecount + (lkcount * (pages-sidepages-1)) %}
+{% endif %}
 {% if _context['linekey_type_' ~ index] == 'blf' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/b'
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/b'
                                     ~ (dss_transfer_map[dss_transfer] ?? 'a')
                                     ~ pickup_direct ~ _context['linekey_value_' ~ index]
                                     }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'conference' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/bf'
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/bf'
                                     ~ pickup_direct ~ _context['linekey_value_' ~ index]
                                     }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'direct_pickup' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_PICKUP
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10)  }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_PICKUP
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'dnd' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_DND
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('DND', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_DND
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('DND', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'dtmf' %}
-Fkey{{ lkidx }} Type               :4
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :4
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'forward' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/a' }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/a' }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'group_pickup' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ pickup_group ~ '@1/f' }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ pickup_group ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Pickup', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'hold' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_HOLD
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Hold', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_HOLD
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Hold', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'ldap' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_LDAPCONTACTS:1
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Phonebook', language)) | slice(0,10)  }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_LDAPCONTACTS:1
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Phonebook', language)) | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'line' %}
-Fkey{{ lkidx }} Type               :2
-Fkey{{ lkidx }} Value              :SIP1
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Line %s', language) | format(lkidx)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :2
+Fkey{{ keyidx }} Value              :SIP1
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Line %s', language) | format(keyidx)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'multicast_paging' %}
-Fkey{{ lkidx }} Type               :14
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '/PCMU' }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index]  | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :14
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '/PCMU' }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index]  | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'phone_lock' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_LOCK
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Lock phone', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_LOCK
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Lock phone', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'prefix' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_PREFIX:{{ _context['linekey_value_' ~ index] }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_PREFIX:{{ _context['linekey_value_' ~ index] }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'recall' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_REDIAL
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Redial', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_REDIAL
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Redial', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'record' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_RECORD
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Record', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_RECORD
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Record', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'speed_dial' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/f' }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'queuetoggle' %}
-Fkey{{ lkidx }} Type               :1
-Fkey{{ lkidx }} Value              :{{ queuetoggle ~ '@1/f' }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ queuetoggle ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'transfer' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_B_TRANSFER
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Transfer', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_B_TRANSFER
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Transfer', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'url' %}
-Fkey{{ lkidx }} Type               :7
-Fkey{{ lkidx }} Value              :{{ _context['linekey_value_' ~ index] }}
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('URL', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :7
+Fkey{{ keyidx }} Value              :{{ _context['linekey_value_' ~ index] }}
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('URL', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% elseif _context['linekey_type_' ~ index] == 'voice_mail' %}
-Fkey{{ lkidx }} Type               :3
-Fkey{{ lkidx }} Value              :F_MWI
-Fkey{{ lkidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Voice mail', language)) | slice(0,10) }}
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_MWI
+Fkey{{ keyidx }} Title              :{{ _context['linekey_label_' ~ index] | default(l10n.gettext('Voice mail', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
 {% else %}
-Fkey{{ lkidx }} Type               :0
-Fkey{{ lkidx }} Value              :
-Fkey{{ lkidx }} Title              :
-Fkey{{ lkidx }} ICON               :Green
+Fkey{{ keyidx }} Type               :0
+Fkey{{ keyidx }} Value              :
+Fkey{{ keyidx }} Title              :
+Fkey{{ keyidx }} ICON               :Green
 {% endif %}
 
 {% endfor %}

--- a/data/templates/fanvil.macros
+++ b/data/templates/fanvil.macros
@@ -200,3 +200,136 @@
     -%}
 {{- map[date_format] ?? '2' -}}
 {% endmacro date_format %}
+
+#
+# Side keys and DSS keys configuration
+#
+{% macro linekey_type_map(
+    linekey_type,
+    linekey_value,
+    linekey_label,
+    keyidx,
+    l10n,
+    language,
+    pickup_direct,
+    pickup_group,
+    dss_transfer,
+    queuetoggle
+) %}
+{% set dss_transfer_map = {
+    'verify': 'c',
+    'blind': 'b',
+    'attended': 'a',
+} %}
+{% if linekey_type == 'blf' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ linekey_value ~ '@1/b'
+                                    ~ (dss_transfer_map[dss_transfer] ?? 'a')
+                                    ~ pickup_direct ~ linekey_value
+                                    }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'conference' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ linekey_value ~ '@1/bf'
+                                    ~ pickup_direct ~ linekey_value
+                                    }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'direct_pickup' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_PICKUP
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Pickup', language)) | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'dnd' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_DND
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('DND', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'dtmf' %}
+Fkey{{ keyidx }} Type               :4
+Fkey{{ keyidx }} Value              :{{ linekey_value }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'forward' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ linekey_value ~ '@1/a' }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'group_pickup' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ pickup_group ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Pickup', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'hold' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_HOLD
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Hold', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'ldap' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_LDAPCONTACTS:1
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Phonebook', language)) | slice(0,10)  }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'line' %}
+Fkey{{ keyidx }} Type               :2
+Fkey{{ keyidx }} Value              :SIP1
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Line %s', language) | format(keyidx)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'multicast_paging' %}
+Fkey{{ keyidx }} Type               :14
+Fkey{{ keyidx }} Value              :{{ linekey_value ~ '/PCMU' }}
+Fkey{{ keyidx }} Title              :{{ linekey_label  | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'phone_lock' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_LOCK
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Lock phone', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'prefix' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_PREFIX:{{ linekey_value }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'recall' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_REDIAL
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Redial', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'record' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_RECORD
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Record', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'speed_dial' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ linekey_value ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'queuetoggle' %}
+Fkey{{ keyidx }} Type               :1
+Fkey{{ keyidx }} Value              :{{ queuetoggle ~ '@1/f' }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'transfer' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_B_TRANSFER
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Transfer', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'url' %}
+Fkey{{ keyidx }} Type               :7
+Fkey{{ keyidx }} Value              :{{ linekey_value }}
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('URL', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% elseif linekey_type == 'voice_mail' %}
+Fkey{{ keyidx }} Type               :3
+Fkey{{ keyidx }} Value              :F_MWI
+Fkey{{ keyidx }} Title              :{{ linekey_label | default(l10n.gettext('Voice mail', language)) | slice(0,10) }}
+Fkey{{ keyidx }} ICON               :Green
+{% else %}
+Fkey{{ keyidx }} Type               :0
+Fkey{{ keyidx }} Value              :
+Fkey{{ keyidx }} Title              :
+Fkey{{ keyidx }} ICON               :Green
+{% endif %}
+{% endmacro linekey_type_map %}

--- a/scripts/upgrade.d/009.php
+++ b/scripts/upgrade.d/009.php
@@ -1,0 +1,43 @@
+<?php namespace upgrade9;
+
+/*
+ * Copyright (C) 2021 Nethesis S.r.l.
+ * http://www.nethesis.it - nethserver@nethesis.it
+ *
+ * This script is part of NethServer.
+ *
+ * NethServer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * or any later version.
+ *
+ * NethServer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NethServer.  If not, see COPYING.
+ */
+
+//
+// Add Fanvil sidekey pages and update Fanvil line key number and pages
+//
+$fixes = [
+    'fanvil-X210' => ['fanvil_sidepages_count' => '1'],
+    'fanvil-X3U' => ['fanvil_lkpages_count' => '0'],
+    'fanvil-X3U' => ['fanvil_sidepages_count' => '1'],
+    'fanvil-X4U' => ['fanvil_sidepages_count' => '1'],
+    'fanvil-X5U' => ['fanvil_sidepages_count' => '1'],
+    'fanvil-X6U' => ['fanvil_sidepages_count' => '1'],
+];
+
+foreach ($fixes as $model_id => $variables) {
+    $scope = new \Tancredi\Entity\Scope($model_id, $container['storage'], $container['logger']);
+    if(isset($scope->metadata['version']) && $scope->metadata['version'] >= 9) {
+        continue;
+    }
+    $scope->metadata['version'] = 9;
+    $scope->setVariables($variables);
+    $container['logger']->info("Add Fanvil sidekey pages and update Fanvil line key number and pages for template X-5 models");
+}


### PR DESCRIPTION
To add Fanvil X7C ( no line key but 60 side key divided into 5 pages) it's necessary to add support for side key pages for all Fanvil phones that use Fanvil-X5 template.


nethesis/dev#5959


