### PR TITLE
Add pickup direct on blf key for Snom phones

### DIFF
--- a/data/templates/snom.macros
+++ b/data/templates/snom.macros
@@ -1,9 +1,9 @@
 #
 # linekey_type_map -- translate "linekey_type_"
 #
-{% macro linekey_type_map(linekey_type, linekey_value, linekey_label, dndtoggle, pickup_group, number, queuetoggle) %}
+{% macro linekey_type_map(linekey_type, linekey_value, linekey_label, dndtoggle, pickup_group, number, queuetoggle, pickup_direct) %}
 {% if linekey_type == "blf" %}
-    <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">blf {{ linekey_value }}</fkey>
+    <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">blf {{ linekey_value }}|{{ pickup_direct }}</fkey>
 {% elseif linekey_type == "conference" %}
     <fkey idx="{{ (number-1) }}" context="1" label="{{ linekey_label }}" lp="on" perm="">conference {{ linekey_value }}</fkey>
 {% elseif linekey_type == "dtmf" %}

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -194,12 +194,12 @@
         {# line keys #}
         {% if cap_linekey_count > 0 %}
             {% for number in 1..(cap_linekey_count) %}
-                    {{snom.linekey_type_map(_context['linekey_type_' ~ number], _context['linekey_value_' ~ number], _context['linekey_label_' ~ number], dndtoggle, pickup_group, number, queuetoggle)}}
+                    {{snom.linekey_type_map(_context['linekey_type_' ~ number], _context['linekey_value_' ~ number], _context['linekey_label_' ~ number], dndtoggle, pickup_group, number, queuetoggle, pickup_direct)}}
             {% endfor %}
         {% endif %}
         {% set expkey_max = cap_expmodule_count * 18 %}
         {% for expkey in (expkey_max > 0 ? range(1,expkey_max) : []) %}
-            {{snom.linekey_type_map(_context['expkey_type_' ~ expkey], _context['expkey_value_' ~ expkey], _context['expkey_label_' ~ expkey], dndtoggle, pickup_group, cap_linekey_count + expkey, queuetoggle)}}
+            {{snom.linekey_type_map(_context['expkey_type_' ~ expkey], _context['expkey_value_' ~ expkey], _context['expkey_label_' ~ expkey], dndtoggle, pickup_group, cap_linekey_count + expkey, queuetoggle, pickup_direct)}}
         {% endfor %}
     </functionKeys>
 {% endautoescape %}


### PR DESCRIPTION
For Snom phones added the direct pickup code to allow you to intercept a call that is ringing in the extension configured in the blf key.
