### PR TITLE
Add g729 to enabled code list for Sangoma phones

### DIFF
--- a/data/templates/sangoma.tmpl
+++ b/data/templates/sangoma.tmpl
@@ -33,6 +33,13 @@
         <P4705 para="Account1.DirectCallPickupCode">{{ pickup_direct }}</P4705>
         <P4706 para="Account1.GroupCallPickupCode">{{ pickup_group }}</P4706>
         <P20157 para="Account1.CallerDisplaySource">3</P20157>
+        <P57 para="Account1.Choice1">0</P57>
+        <P58 para="Account1.Choice2">8</P58>
+        <P59 para="Account1.Choice3">9</P59>
+        <P60 para="Account1.Choice4">18</P60>
+        <P61 para="Account1.Choice5">3</P61>
+        <P62 para="Account1.Choice6">2</P62>
+        <P37 para="Account1.VoiceFramesPerTX">2</P37>
         {%- endif %}
 
         <!--Network/Basic-->


### PR DESCRIPTION
G729 is disabled on the default Sangoma phone configuration.
It is necessary to enable g729 a list with codec enabled on default configuration + g729