### PR TITLE
Remove codec g722 for Gigaset Phones

### DIFF
--- a/data/templates/gigaset-Maxwell.tmpl
+++ b/data/templates/gigaset-Maxwell.tmpl
@@ -42,6 +42,7 @@
     <param name="SIP.DefaultRingtone" value="{{ gigaset.ringtone_map(ringtone) }}" />
 
     <param name="SIP.DefaultAccount" value="0" />
+    <param name="SIP.ActiveCodecs" value="0,8,18" />
 
     {% for line in range(1,4) -%}
     {%- if _context['account_username_' ~ line] is defined -%}


### PR DESCRIPTION
Remove codec g722 enabling only g711a, g711u and g729

0 = uLaw
8 = aLaw
9 = g.722
18 = G.729
109 = iLBC
115 = g.726-32 