### PR TITLE
Cosmetic fix: update nethesis/dev#6007 always created custom scopes

### DIFF
--- a/data/scopes/fanvil-X3U.ini
+++ b/data/scopes/fanvil-X3U.ini
@@ -1,7 +1,7 @@
 [metadata]
 scopeType = "model"
 displayName = "Fanvil X3U"
-version = 9
+version = 11
 
 [data]
 cap_ldap_tls_blacklist =

--- a/data/scopes/yealink-T43.ini
+++ b/data/scopes/yealink-T43.ini
@@ -1,7 +1,7 @@
 [metadata]
 scopeType = "model"
 displayName = "Yealink T43U"
-version = 10
+version = 11
 
 [data]
 cap_contrast = "1"
@@ -21,7 +21,7 @@ cap_linekey_count = 21
 cap_linekey_type_blacklist = ""
 cap_softkey_count = 4
 cap_softkey_type_blacklist = ""
-cap_expkey_count = 60
+cap_expkey_count = 40
 cap_expkey_type_blacklist = 
 cap_ringtone_count = 10
 cap_ringtone_blacklist =


### PR DESCRIPTION
Those files were created because version of default file was < 11, but update script check if versionis >= 11.
Two scopes were created on a fresh install Tancredi, even if it wasn't necessary. 
This is only cosmetic.