### PR TITLE
Add Snom SP800 and minor fix to template

### DIFF
--- a/data/scopes/snom-SP800.ini
+++ b/data/scopes/snom-SP800.ini
@@ -1,0 +1,42 @@
+[metadata]
+scopeType = "model"
+displayName = "Snom SP800"
+version = 12
+
+[data]
+screensaver_time =
+cap_screensaver_time_blacklist = "0,3,5,7,10,15,30,60,120,300,600,1200,1800,2400,3000,3600"
+cap_backlight_time_blacklist = "0"
+cap_contrast = ""
+cap_screensaver_file = ""
+cap_background_file = "1"
+cap_backlight_time_blacklist = ""
+backlight_time = 30
+cap_ldap_tls_blacklist = starttls
+provisioning_url_filename = "{mac}.xml"
+tmpl_phone = "snomD8XX.tmpl"
+tmpl_firmware = "snom-firmware.tmpl"
+cap_linekey_count = 28
+cap_linekey_type_blacklist = "direct_pickup,hold,ldap,phone_lock,prefix,recall,voice_mail"
+cap_softkey_count = 4
+cap_softkey_type_blacklist =
+cap_expkey_count =
+cap_expkey_type_blacklist =
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist = "verify"
+cap_date_format_blacklist = "DD MM YYYY,DD MMM WW,DD MMM YY,DD MMM YYYY,WWW DD MMM,WWW MMM DD,MM DD YYYY,MMM DD WW,YY MM DD,YYYY MM DD"
+
+linekey_type_1 = "line"
+linekey_type_2 = "line"
+
+softkey_type_1 = "history"
+softkey_type_2 = "forward"
+softkey_type_3 = "recall"
+softkey_type_4 = "menu"
+cap_expkey_count = 18
+cap_expkey_type_blacklist = "direct_pickup,hold,ldap,phone_lock,prefix,recall,voice_mail"
+cap_expmodule_count = 3
+
+ldap_number_filter = "(|(telephoneNumber=%*)(mobile=%*)(homePhone=%*))"
+ldap_name_filter = "(|(cn=%*)(o=%*))"

--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -38,6 +38,10 @@
 
         <transfer_on_hangup perm="">on</transfer_on_hangup>
         <transfer_on_hangup_non_pots perm="">on</transfer_on_hangup_non_pots>
+        <auto_dial perm="">4</auto_dial>
+        <keyboard_lock_emergency perm=""></keyboard_lock_emergency>
+        <dtmf_speaker_phone perm="">off</dtmf_speaker_phone>
+        <guess_number perm="">off</guess_number>
 
         <ntp_server perm="">{{ ntp_server ?: 'pool.ntp.org' }}</ntp_server>
         <date_us_format perm="">{{ snom.date_format(date_format) }}</date_us_format>


### PR DESCRIPTION
Add Snom SP800.


Minor fixes to Snom template:

- Disable guessing number to not speed down call completion
- Disable hearing DTMF tones during call initiation 
- Autodial setting to dial the number on the display after 4 seconds
