### PR TITLE
Snom: removed 18 as max exp keys

### DIFF
--- a/data/templates/snom.tmpl
+++ b/data/templates/snom.tmpl
@@ -206,7 +206,7 @@
                     {{snom.linekey_type_map(_context['linekey_type_' ~ number], _context['linekey_value_' ~ number], _context['linekey_label_' ~ number], dndtoggle, pickup_group, number, queuetoggle, pickup_direct)}}
             {% endfor %}
         {% endif %}
-        {% set expkey_max = cap_expmodule_count * 18 %}
+        {% set expkey_max = cap_expmodule_count * cap_expkey_count %}
         {% for expkey in (expkey_max > 0 ? range(1,expkey_max) : []) %}
             {{snom.linekey_type_map(_context['expkey_type_' ~ expkey], _context['expkey_value_' ~ expkey], _context['expkey_label_' ~ expkey], dndtoggle, pickup_group, cap_linekey_count + expkey, queuetoggle, pickup_direct)}}
         {% endfor %}


### PR DESCRIPTION
Snom: removed 18 as max exp keys and used scope variable cap_expkey_count instead