### PR TITLE
Fix(Yealink): Allow only AES_CM_128_HMAC_SHA1_80 / AES_CM_128_HMAC_SHA1_32 ciphers on T3* & T4*

### DIFF
--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -1863,7 +1863,7 @@ account.{{ line }}.srtp_encryption = {{ _context['account_encryption_' ~ line] ?
 account.{{ line }}.srtp_unencrypted_rtp.enable = 0
 account.{{ line }}.srtp.unencrypted_rtcp.enable = 0
 # Fix SRTP error
-{% if provisioning_user_agent matches '/SIP-(T34|T44)(U|W)/' %}
+{% if provisioning_user_agent matches '/SIP-(T3|T4)/' %}
 account.{{ line }}.srtp.cipher_list = AES_CM_128_HMAC_SHA1_80,AES_CM_128_HMAC_SHA1_32
 {% endif %}
 account.{{ line }}.ptime = 20


### PR DESCRIPTION
Use a less restrictive regular expression to force AES_CM_128_HMAC_SHA1_80 / AES_CM_128_HMAC_SHA1_32 ciphers. 
Doing this now all phones that belongs  to T3x and T4x families will use only those two ciphers
https://github.com/NethServer/dev/issues/7361