### PR TITLE
add Yealink T7X T8X AX

### DIFF
--- a/data/scopes/yealink-AX83.ini
+++ b/data/scopes/yealink-AX83.ini
@@ -1,0 +1,37 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink AX83H"
+version = 4
+
+[data]
+cap_contrast = "1"
+contrast = 6
+cap_brightness = ""
+brightness =
+cap_screensaver_file = ""
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = ""
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 30
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 0
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 2
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 0
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 0
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""

--- a/data/scopes/yealink-AX86.ini
+++ b/data/scopes/yealink-AX86.ini
@@ -1,0 +1,40 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink AX86R"
+version = 4
+
+[data]
+cap_contrast = "1"
+contrast = 6
+cap_brightness = ""
+brightness =
+cap_screensaver_file = ""
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = ""
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 30
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 0
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 3
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 0
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 0
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""

--- a/data/scopes/yealink-T73.ini
+++ b/data/scopes/yealink-T73.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T73U/W"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 40
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/scopes/yealink-T74.ini
+++ b/data/scopes/yealink-T74.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T74U/W"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 50
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/scopes/yealink-T77.ini
+++ b/data/scopes/yealink-T77.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T77U"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 56
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/scopes/yealink-T85.ini
+++ b/data/scopes/yealink-T85.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T85W"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 60
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/scopes/yealink-T87.ini
+++ b/data/scopes/yealink-T87.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T87W"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 84
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/scopes/yealink-T88.ini
+++ b/data/scopes/yealink-T88.ini
@@ -1,0 +1,50 @@
+[metadata]
+scopeType = "model"
+displayName = "Yealink T88V/W"
+version = 4
+
+[data]
+cap_contrast = ""
+contrast = 
+cap_brightness = 1
+brightness = 8
+cap_screensaver_file = "1"
+cap_screensaver_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+screensaver_time = 600
+cap_background_file = "1"
+cap_backlight_time_blacklist = "3,5,7,10,1200,2400,3000,3600"
+backlight_time = 0
+cap_ldap_tls_blacklist =
+provisioning_url_filename = 
+tmpl_phone = "yealink.tmpl"
+cap_linekey_count = 84
+cap_linekey_type_blacklist = ""
+cap_softkey_count = 4
+cap_softkey_type_blacklist = ""
+cap_expkey_count = 78
+cap_expkey_type_blacklist = 
+cap_ringtone_count = 10
+cap_ringtone_blacklist =
+cap_dss_transfer_blacklist =
+cap_expmodule_count = 3
+cap_date_format_blacklist = "DD MM YY,DD MMM WW,MM DD YYYY,MMM DD WW,YY MM DD"
+
+softkey_type_1 = "history"
+softkey_value_1 = ""
+softkey_label_1 = ""
+softkey_type_2 = "ldap"
+softkey_value_2 = ""
+softkey_label_2 = ""
+softkey_type_3 = "group_pickup"
+softkey_value_3 = ""
+softkey_label_3 = ""
+softkey_type_4 = "menu"
+softkey_value_4 = ""
+softkey_label_4 = ""
+
+linekey_type_1 = "line"
+linekey_value_1 = ""
+linekey_label_1 = ""
+linekey_type_2 = "line"
+linekey_value_2 = ""
+linekey_label_2 = ""

--- a/data/templates/yealink.tmpl
+++ b/data/templates/yealink.tmpl
@@ -1863,7 +1863,7 @@ account.{{ line }}.srtp_encryption = {{ _context['account_encryption_' ~ line] ?
 account.{{ line }}.srtp_unencrypted_rtp.enable = 0
 account.{{ line }}.srtp.unencrypted_rtcp.enable = 0
 # Fix SRTP error
-{% if provisioning_user_agent matches '/SIP-(T3|T4)/' %}
+{% if provisioning_user_agent matches '/(SIP-(T3|T4|T7|T8))|(AX8)/' %}
 account.{{ line }}.srtp.cipher_list = AES_CM_128_HMAC_SHA1_80,AES_CM_128_HMAC_SHA1_32
 {% endif %}
 account.{{ line }}.ptime = 20


### PR DESCRIPTION
Add support for the following new Yealink phone models in Tancredi to enable automatic provisioning via NethVoice:

- T7X Series: SIP-T73U, SIP-T73W, SIP-T74U, SIP-T74W, SIP-T77U

- T8X Series: SIP-T85W, SIP-T87W, SIP-T88W

- AXX Series: AX83H, AX86R


https://github.com/NethServer/dev/issues/7469
