### PR TITLE
fix(nethesis): bump NP-X5 model metadata to 15

### DIFF
--- a/data/scopes/nethesis-NPX5.ini
+++ b/data/scopes/nethesis-NPX5.ini
@@ -1,7 +1,7 @@
 [metadata]
 scopeType = "model"
 displayName = "Nethesis NP-X5"
-version = 14
+version = 15
 
 [data]
 cap_ldap_tls_blacklist =


### PR DESCRIPTION
The nethesis-NPX5 model now carries the unified NP-X5 and NP-X5 v2 provisioning settings, including tmpl_firmware_v2 used by the v2 firmware path.

Keep the shipped model metadata version aligned with the latest upgrade state by raising nethesis-NPX5.ini from version 14 to version 15. This ensures writable scopes created from the packaged model inherit the new version baseline and stay consistent with the custom migration added for legacy nethesis-NPX5v2 descendants.

Refs: NethServer/dev#7478
Refs: NethServer/dev#7927