### PR TITLE
fix(provisioning): Prefer writable patterns

### DIFF
--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -25,7 +25,9 @@ The provisioning entrypoint exposes these routes:
 For provisioning payload requests, Tancredi resolves the response in five
 steps:
 
-1. Match the requested filename against the rules from `data/patterns.d/*.ini`.
+1. Match the requested filename against the rules from
+  `rw_dir/patterns.d/*.ini` and then `ro_dir/patterns.d/*.ini`, with writable
+  files taking precedence over shipped files with the same name.
 1. Read the selected rule `scopeid`, template variable name and content type.
 1. Load the scope and merge variables in the order `defaults` → `model` →
    `phone`.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -30,7 +30,16 @@ At render time Tancredi loads templates in this order:
 
 When a phone requests a file, Tancredi establishes what template has to be
 interpolated to build the response by looking at the `.ini` files under the
-`data/patterns.d` directory.
+`patterns.d` directories.
+
+At match time Tancredi loads request rules in this order:
+
+1. `rw_dir/patterns.d/`
+1. `ro_dir/patterns.d/`
+
+If a writable pattern file has the same name as a shipped one, the writable
+file replaces it. Because the first matching rule wins, rules from `rw_dir`
+can both add new matches and override shipped matches.
 
 Each `.ini` file in that directory defines one or more request matching rules.
 The rule definition has the following lines:

--- a/public/provisioning.php
+++ b/public/provisioning.php
@@ -281,24 +281,75 @@ function resolveStaticAssetPath($filetype, $filename) {
     return FALSE;
 }
 
-function getDataFromFilename($filename,$logger) {
+function getPatternFiles($logger) {
     global $config;
+
+    $pattern_files = array();
+    $rw_pattern_files = glob(rtrim($config['rw_dir'], '/') . '/patterns.d/*.ini');
+    $ro_pattern_files = glob(rtrim($config['ro_dir'], '/') . '/patterns.d/*.ini');
+    $rw_pattern_files = $rw_pattern_files === FALSE ? array() : $rw_pattern_files;
+    $ro_pattern_files = $ro_pattern_files === FALSE ? array() : $ro_pattern_files;
+    $overridden_pattern_files = array();
+    $ro_pattern_files_by_name = array();
+
+    foreach ($ro_pattern_files as $pattern_file) {
+        $ro_pattern_files_by_name[basename($pattern_file)] = $pattern_file;
+    }
+
+    foreach ($rw_pattern_files as $pattern_file) {
+        $pattern_basename = basename($pattern_file);
+        if (isset($ro_pattern_files_by_name[$pattern_basename])) {
+            $logger->debug(
+                'Writable pattern file "{rw_pattern_file}" overrides shipped pattern file "{ro_pattern_file}"',
+                array(
+                    'rw_pattern_file' => $pattern_file,
+                    'ro_pattern_file' => $ro_pattern_files_by_name[$pattern_basename],
+                )
+            );
+        } else {
+            $logger->debug('Using writable pattern file "{rw_pattern_file}"', array(
+                'rw_pattern_file' => $pattern_file,
+            ));
+        }
+
+        $pattern_files[] = $pattern_file;
+        $overridden_pattern_files[$pattern_basename] = TRUE;
+    }
+
+    foreach ($ro_pattern_files as $pattern_file) {
+        if (!isset($overridden_pattern_files[basename($pattern_file)])) {
+            $logger->debug('Using shipped pattern file "{ro_pattern_file}"', array(
+                'ro_pattern_file' => $pattern_file,
+            ));
+            $pattern_files[] = $pattern_file;
+        }
+    }
+
+    return $pattern_files;
+}
+
+function getDataFromFilename($filename,$logger) {
     $result = array(
         'filename' => $filename,
     );
-    $patterns = array();
-    foreach (glob($config['ro_dir'] . 'patterns.d/*.ini') as $pattern_file) {
-        $patterns = array_merge($patterns, parse_ini_file($pattern_file, true));
-    }
-    foreach ($patterns as $pattern_name => $pattern) {
-        if (preg_match('/^'.$pattern['pattern'].'$/', $filename, $tmp)) {
-            $result['pattern_name'] = $pattern_name;
-            $result['template'] = $pattern['template'];
-            $result['scopeid'] = preg_replace('/'.$pattern['pattern'].'/', $pattern['scopeid'] , $filename );
-            $result['content_type'] = empty($pattern['content_type']) ? 'text/plain; charset=utf-8' : $pattern['content_type'];
-            break;
+
+    foreach (getPatternFiles($logger) as $pattern_file) {
+        $patterns = parse_ini_file($pattern_file, true);
+        if ($patterns === FALSE) {
+            continue;
+        }
+
+        foreach ($patterns as $pattern_name => $pattern) {
+            if (preg_match('/^'.$pattern['pattern'].'$/', $filename, $tmp)) {
+                $result['pattern_name'] = $pattern_name;
+                $result['template'] = $pattern['template'];
+                $result['scopeid'] = preg_replace('/'.$pattern['pattern'].'/', $pattern['scopeid'] , $filename );
+                $result['content_type'] = empty($pattern['content_type']) ? 'text/plain; charset=utf-8' : $pattern['content_type'];
+                return $result;
+            }
         }
     }
+
     return $result;
 }
 

--- a/test/bats/50_template_rendering.bats
+++ b/test/bats/50_template_rendering.bats
@@ -2,13 +2,17 @@
 
 TEMPLATE_CUSTOM_DIR="${TANCREDI_TEMPLATE_CUSTOM_DIR:-/var/lib/tancredi/data/templates-custom/}"
 TEMPLATE_CUSTOM_FILE="${TEMPLATE_CUSTOM_DIR%/}/nethesis-firmware-v2.tmpl"
+PATTERN_CUSTOM_FILE="${TANCREDI_RW_DIR:-/var/lib/tancredi/data/}"
+PATTERN_CUSTOM_FILE="${PATTERN_CUSTOM_FILE%/}/patterns.d/zz-yealink-override.ini"
+PATTERN_OVERRIDE_FILE="${TANCREDI_RW_DIR:-/var/lib/tancredi/data/}"
+PATTERN_OVERRIDE_FILE="${PATTERN_OVERRIDE_FILE%/}/patterns.d/yealink.ini"
 
 setup () {
     load tancredi_client
 }
 
 teardown_file () {
-    rm -f "$TEMPLATE_CUSTOM_FILE"
+    rm -f "$TEMPLATE_CUSTOM_FILE" "$PATTERN_CUSTOM_FILE" "$PATTERN_OVERRIDE_FILE"
 }
 
 @test "POST /tancredi/api/v1/phones (00-15-65-AA-BB-CC, Yealink T46, success)" {
@@ -131,6 +135,56 @@ EOF
     # Compare against fixture
     fixture_file="${BATS_TEST_DIRNAME}/../fixtures/yealink-t46-expected.cfg"
     assert_template_matches_fixture "$fixture_file"
+}
+
+@test "GET /provisioning/{tok1}/001565aabbcc.cfg prefers rw patterns.d over ro patterns.d" {
+    mkdir -p "$(dirname "$PATTERN_CUSTOM_FILE")"
+    cat > "$PATTERN_CUSTOM_FILE" <<'EOF'
+[yealink-rw-override]
+pattern = "001565aabbcc\.cfg"
+scopeid = "ignored"
+template = "tmpl_phone"
+content_type = "application/x-rw-pattern"
+EOF
+
+    run GET /tancredi/api/v1/phones/00-15-65-AA-BB-CC
+    assert_http_code "200"
+
+    tok1=$(extract_field "tok1")
+
+    if [[ -z "$tok1" ]]; then
+        echo "Failed to extract tok1 token" 1>&2
+        return 1
+    fi
+
+    run GET_PROVISIONING "Yealink SIP-T46G 41.0.0.0 00:15:65:aa:bb:cc" "/provisioning/${tok1}/001565aabbcc.cfg"
+    assert_http_code "200"
+    assert_http_header "Content-Type" "application/x-rw-pattern"
+}
+
+@test "GET /provisioning/{tok1}/001565aabbcc.cfg allows rw patterns.d to replace a shipped file" {
+    mkdir -p "$(dirname "$PATTERN_OVERRIDE_FILE")"
+    cat > "$PATTERN_OVERRIDE_FILE" <<'EOF'
+[yealink-rw-file-override]
+pattern = "001565aabbcc\.cfg"
+scopeid = "ignored"
+template = "tmpl_phone"
+content_type = "application/x-rw-pattern-override"
+EOF
+
+    run GET /tancredi/api/v1/phones/00-15-65-AA-BB-CC
+    assert_http_code "200"
+
+    tok1=$(extract_field "tok1")
+
+    if [[ -z "$tok1" ]]; then
+        echo "Failed to extract tok1 token" 1>&2
+        return 1
+    fi
+
+    run GET_PROVISIONING "Yealink SIP-T46G 41.0.0.0 00:15:65:aa:bb:cc" "/provisioning/${tok1}/001565aabbcc.cfg"
+    assert_http_code "200"
+    assert_http_header "Content-Type" "application/x-rw-pattern-override"
 }
 
 @test "DELETE /tancredi/api/v1/phones/00-15-65-AA-BB-CC (cleanup)" {

--- a/test/bats/tancredi_client.bash
+++ b/test/bats/tancredi_client.bash
@@ -36,6 +36,7 @@ tancredi_ensure_rw_layout () {
         "${tancredi_rw_dir}backgrounds" \
         "${tancredi_rw_dir}firmware" \
         "${tancredi_rw_dir}first_access_tokens" \
+    "${tancredi_rw_dir}patterns.d" \
         "${tancredi_rw_dir}ringtones" \
         "${tancredi_rw_dir}scopes" \
         "${tancredi_rw_dir}screensavers" \

--- a/test/run.sh
+++ b/test/run.sh
@@ -68,6 +68,7 @@ create_rw_layout() {
         "${TANCREDI_RW_DIR%/}/backgrounds" \
         "${TANCREDI_RW_DIR%/}/firmware" \
         "${TANCREDI_RW_DIR%/}/first_access_tokens" \
+    "${TANCREDI_RW_DIR%/}/patterns.d" \
         "${TANCREDI_RW_DIR%/}/ringtones" \
         "${TANCREDI_RW_DIR%/}/scopes" \
         "${TANCREDI_RW_DIR%/}/screensavers" \


### PR DESCRIPTION
Evaluate files under rw_dir/patterns.d before shipped pattern files. When a writable pattern has the same basename as a shipped one, use the writable file so users can add rules and override existing request matches.
https://github.com/NethServer/dev/issues/8063